### PR TITLE
Document advanced lighting investigation and checkpoint policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## DOCS-2026-07-12-008 — Advanced Lighting Investigation Checkpoint
+
+Date: 2026-07-12
+Time: 14:08 PDT
+
+### Added
+
+- Added `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md` as the dedicated source for HeroForge custom-light injection, shadow-path behavior, SphereLight failure findings, canvas/preset confounders, lifecycle risks, and queued Fresnel/rim-light work.
+- Added a durable milestone-based documentation-checkpoint policy: validated findings, corrections, status changes, decisions, blockers, and material probe milestones must be persisted in GitHub documentation rather than left only in chat.
+
+### Changed
+
+- Updated `MASTER.md` with Advanced Lighting Controls and Camera-Relative Rim Lighting status, active tasks, migration queue entries, watch items, rejected assumptions, and documentation-as-project-memory rules.
+- Updated `HISTORY/Bullshit_Bible.md` with lighting/shadow critical rules, the new topic-file index entry, and documentation checkpoint/correction rules.
+- Updated `HISTORY/STANDALONE_REFERENCES.md` with exact inventory/status notes for Lighting Probe v0.1.0, Lighting Injection Probe v0.1.0-v0.3.0, and the queued rim-light shader probe.
+- Updated `HISTORY/DECISIONS.md` with durable decisions for milestone-based documentation checkpoints and separation of physical lighting, shader-based rim lighting, and Persistent Booth.
+- Updated `HISTORY/SESSION_LOG.md` with the current lighting investigation state and next diagnostic priority.
+- Updated `PRE_FLIGHT_Check.md` with target files, history reviewed, connected systems, conflict risks, and recommended action.
+
+### Confirmed / Corrected Documentation
+
+- Confirmed a second custom DirectionalLight visibly renders and supports position and intensity changes.
+- Confirmed pre-attachment `castShadow: true` can allocate an independent custom shadow map and calculated matrix in Photo Booth.
+- Documented the unresolved stale-shadow-matrix behavior after later movement/state changes.
+- Corrected the earlier assumption that `numDirLightShadows` must become `1`; visible custom shadows and an allocated map were observed while the inspected value remained `0`.
+- Corrected native SphereLight count interpretation: count reductions in the isolation test were caused by manual user toggles, not HeroForge lifecycle removal.
+- Documented that a third SphereLight being counted does not prove visible contribution; it remained visually inactive even as the sole registered SphereLight.
+- Preserved Persistent Booth as live/working and separate; Witch Dock is not proven to have caused the later shadow regression.
+
+### Touched Files
+
+- `MASTER.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+### Rollback Notes
+
+- Documentation-only checkpoint.
+- No JavaScript files changed.
+- No userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- Removing this update would discard the durable lighting investigation record and documentation-checkpoint policy, but would not alter live Witch Dock behavior.
+
+### Test Notes
+
+- Not applicable. Documentation-only update.
+- Documentation was cross-checked against the current standalone probe reports and user-observed test results.
+
 ## DOCS-2026-07-09-007 — Standalone Reference Inventory Backfill
 
 Date: 2026-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Time: 14:08 PDT
 ### Changed
 
 - Updated `MASTER.md` with Advanced Lighting Controls and Camera-Relative Rim Lighting status, active tasks, migration queue entries, watch items, rejected assumptions, and documentation-as-project-memory rules.
+- Updated `HISTORY/README.md` with documentation-checkpoint rules and a link to the lighting/shadow topic file.
 - Updated `HISTORY/Bullshit_Bible.md` with lighting/shadow critical rules, the new topic-file index entry, and documentation checkpoint/correction rules.
 - Updated `HISTORY/STANDALONE_REFERENCES.md` with exact inventory/status notes for Lighting Probe v0.1.0, Lighting Injection Probe v0.1.0-v0.3.0, and the queued rim-light shader probe.
 - Updated `HISTORY/DECISIONS.md` with durable decisions for milestone-based documentation checkpoints and separation of physical lighting, shader-based rim lighting, and Persistent Booth.
@@ -32,6 +33,7 @@ Time: 14:08 PDT
 ### Touched Files
 
 - `MASTER.md`
+- `HISTORY/README.md`
 - `HISTORY/Bullshit_Bible.md`
 - `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
 - `HISTORY/STANDALONE_REFERENCES.md`

--- a/HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md
+++ b/HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md
@@ -1,0 +1,473 @@
+# Lighting and Shadows
+
+HeroForge lighting, custom-light injection, shadow-path, lifecycle, and future rim-lighting discoveries.
+
+## Status
+
+Investigating / unresolved.
+
+Current position:
+
+- A second custom non-shadow DirectionalLight is confirmed working in the editor and Photo Booth.
+- DirectionalLight position and intensity controls are confirmed working.
+- The custom DirectionalLight survives normal editor <-> Photo Booth transitions in standalone probe testing.
+- Independent DirectionalLight shadow allocation is confirmed in Photo Booth when `castShadow` is enabled before first attachment.
+- Shadow refresh after later light movement or broader Photo Booth/canvas-state changes is unresolved.
+- A third injected SphereLight is counted by materials but does not visibly illuminate the figure.
+- Camera-relative Fresnel/rim lighting is queued after the physical DirectionalLight path is stabilized.
+- None of this work is currently a live Witch Dock module.
+
+## Documentation Confidence Labels
+
+Use these labels when extending this file:
+
+- **Confirmed:** directly observed in runtime and supported by probe output.
+- **Observed:** user-visible behavior reported during a controlled test, but not fully isolated internally.
+- **Inferred:** best current explanation supported by evidence, but not directly proven.
+- **Unproven:** plausible path or hypothesis that still needs a probe.
+
+When a later test disproves an earlier statement, correct or replace the old statement. Do not leave contradictory claims active in separate sections without an explicit historical note.
+
+## Probe Inventory
+
+### HeroForge Lighting Probe v0.1.0
+
+Status:
+
+- Read-only diagnostic probe.
+
+Files:
+
+- `HeroForge_Lighting_Probe_v0.1.0.txt`
+- `HeroForge_Lighting_Probe_v0.1.0_diff.txt`
+
+Purpose:
+
+- Scan globals, object graphs, light constructors, active lighting roots, material light counts, and bundle support.
+- Export diagnostic JSON without mutating the scene.
+
+Rule:
+
+- Keep this read-only probe separate from injection probes.
+- Do not alter it to perform active light injection.
+
+### HeroForge Lighting Injection Probe v0.1.0
+
+Status:
+
+- Unresolved probe / partial success.
+
+Files:
+
+- `HeroForge_Lighting_Injection_Probe_v0.1.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.1.0_diff.txt`
+
+Confirmed results:
+
+- Injected a third SphereLight that was counted by the material system but did not visibly illuminate the figure.
+- Injected a second non-shadow DirectionalLight that visibly illuminated the figure.
+- Established tolerant scene/light discovery and owned-object cleanup.
+
+### HeroForge Lighting Injection Probe v0.2.0
+
+Status:
+
+- Unresolved probe / control and transform diagnostics.
+
+Files:
+
+- `HeroForge_Lighting_Injection_Probe_v0.2.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.2.0_diff.txt`
+
+Added tests:
+
+- DirectionalLight position presets.
+- Target-height presets.
+- Intensity presets.
+- Post-attachment shadow toggle.
+- Expanded transform, matrix, shadow-camera, map, and material diagnostics.
+
+Observed results:
+
+- Position changing worked in editor and Photo Booth.
+- Intensity changing worked in editor and Photo Booth.
+- Target changes did not visibly affect the editor, but did visibly affect Photo Booth.
+- Enabling shadows after the light was already attached did not produce a reliable visible custom-shadow result.
+
+### HeroForge Lighting Injection Probe v0.3.0
+
+Status:
+
+- Current canonical lighting injection probe.
+- Partial working reference, not a finished tool.
+
+Files:
+
+- `HeroForge_Lighting_Injection_Probe_v0.3.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.3.0_diff.txt`
+
+Key change:
+
+- Added a DirectionalLight injection path with `castShadow: true` set before first scene attachment.
+- Added controlled detach/re-attach shadow testing.
+
+Confirmed results:
+
+- The custom DirectionalLight rendered and remained controllable.
+- Photo Booth allocated an independent custom shadow map.
+- The custom shadow matrix changed from identity to a calculated projection matrix after Photo Booth became active.
+- Shadow allocation did not require replacing or sharing the native sun's shadow object.
+- The same custom light, target, and group identities remained attached during the successful test.
+
+Current unresolved result:
+
+- In a later test, the shadow map and non-identity matrix still existed, but the matrix remained unchanged after the light moved.
+- Detach/re-attach did not force the matrix to update.
+- The visible result was that custom shadows appeared absent, frozen, misplaced, or otherwise no longer matched the moved light.
+
+## Runtime Lighting Structure
+
+### Confirmed Exports
+
+`RK` exposes at least:
+
+- `PointLight`
+- `SphereLight`
+- `HemisphereLight`
+- `EnvironmentLight`
+- `DirectionalLight`
+- `AmbientLight`
+- `Light`
+
+Renderer/shader paths were observed dynamically supporting counts for:
+
+- directional lights;
+- point lights;
+- sphere lights;
+- spot lights;
+- rectangular area lights;
+- hemisphere lights;
+- environment lights.
+
+This means HeroForge's visible two-orb UI is not a universal renderer light-count cap.
+
+### Active Rig Discovery
+
+Confirmed reachable paths/signals include:
+
+- `CK.environment`
+- `CK.environment.lighting`
+- `HF.summonCircle.parent.parent.lighting`
+- a child named `lighting`
+- scene-traversal fallback
+
+The active lighting object has exposed or observed:
+
+- `name === "lighting"`
+- `sunlight`
+- `_partLightGroup`
+- `partLights`
+- `partLightDefaults`
+
+Rules:
+
+- Do not hard-code `CK.environment.children[3]` or any one numeric child path.
+- Preserve tolerant alias checks and scene traversal.
+- UUIDs are runtime-instance diagnostics, not stable selectors.
+
+### Custom Attachment Path
+
+The working probe creates an owned custom group by cloning the native part-light group non-recursively, then attaches that group as a sibling of native `partLights` under `Character0`.
+
+Confirmed implications:
+
+- General scene traversal can discover a custom DirectionalLight under that sibling group.
+- The sibling attachment itself does not prevent DirectionalLight illumination.
+- The SphereLight failure is therefore type-specific, not proof that the custom group is globally invalid.
+
+## Second DirectionalLight
+
+### Confirmed Working Behavior
+
+A cloned custom DirectionalLight can:
+
+- visibly illuminate the figure;
+- use an independent color;
+- use an independent intensity;
+- move between tested positions;
+- use an independent target object;
+- persist through normal editor <-> Photo Booth transitions in standalone tests;
+- be counted alongside the native sun as a second directional light.
+
+Do not call it a second sun.
+
+It is currently a cloned custom DirectionalLight. HeroForge's native sun has additional sun-specific systems and singular shadow paths that are not automatically duplicated.
+
+### Position
+
+Confirmed:
+
+- Position presets changed the visible illumination direction.
+- Tested positions included front, back, left, right, above, and below.
+
+Required implementation behavior:
+
+- Refresh local/world matrices after position mutation.
+- Preserve tolerant method checks such as `setMatrixNeedsUpdate`, `updateMatrix`, and `updateMatrixWorld` where available.
+
+### Targeting
+
+Confirmed:
+
+- The target object moved between feet, center, and head positions.
+- Photo Booth visibly responded to target changes.
+
+Observed limitation:
+
+- The editor did not visibly respond to the same target changes during the v0.2 test.
+
+Current interpretation:
+
+- Target assignment itself is valid.
+- Editor and Photo Booth likely differ in when or how directional vectors are refreshed or consumed.
+- Exact editor suppression/update behavior remains unproven.
+
+### Intensity
+
+Confirmed:
+
+- Runtime intensity mutation visibly changed the custom DirectionalLight.
+- Tested values included low, medium, high, off, and numeric values.
+
+## Directional Shadows
+
+### Pre-Attach Requirement
+
+Confirmed:
+
+- Setting `castShadow: true` before the custom DirectionalLight is first attached produced a Photo Booth shadow map and calculated shadow matrix.
+- Toggling `castShadow` only after attachment was not a reliable working path.
+
+Canonical rule for the current probe:
+
+1. Clone the native DirectionalLight.
+2. Create or retain an independent shadow object.
+3. Set `castShadow: true` before first attachment.
+4. Attach the target and light under the owned custom group.
+5. Enter or operate in Photo Booth so HeroForge allocates the shadow pass.
+
+### Photo Booth vs Editor
+
+Confirmed during successful v0.3 testing:
+
+- In editor state, the custom shadow object existed but its map was null and its matrix remained identity.
+- After Photo Booth became active, a custom shadow map was allocated and the matrix became non-identity.
+
+Current rule:
+
+- Treat Photo Booth as the confirmed custom-shadow execution environment.
+- Do not claim editor custom shadows are working until directly demonstrated.
+
+### Material Shadow Counters
+
+Important correction:
+
+- `numDirLightShadows` remained `0` even during the run where the user visibly observed shadows and the probe showed an allocated independent map and non-identity matrix.
+
+Therefore:
+
+- `numDirLightShadows` is not a reliable success criterion for HeroForge's observed Photo Booth custom-shadow path.
+- Stronger indicators are `castShadow`, map allocation, calculated matrix state, and visible moving shadows.
+
+### Stale Shadow Matrix
+
+Confirmed in the later v0.3 report:
+
+- The custom light moved through substantially different positions.
+- The shadow map remained allocated.
+- `castShadow` remained true.
+- The shadow matrix remained byte-for-byte unchanged.
+- Controlled detach/re-attach did not refresh the matrix.
+
+Current diagnosis:
+
+- The light itself remains valid and visibly controllable.
+- The custom shadow pass can become stale after later movement or broader Photo Booth state changes.
+- A dedicated shadow-camera/matrix refresh path is required before the feature can be considered stable.
+
+Unproven candidates for the next probe:
+
+- explicit shadow `needsUpdate`/`autoUpdate` handling where supported;
+- direct shadow-camera matrix updates;
+- renderer shadow-map invalidation;
+- controlled target refresh;
+- identifying the internal Photo Booth update that recalculates native sun shadows;
+- recreating only the custom shadow object without replacing the light;
+- reinjection after canvas/preset state commits.
+
+Do not patch material uniforms blindly before identifying the live renderer-owned update path.
+
+## Canvas Presets and Persistent Booth
+
+### Canvas Presets
+
+Observed:
+
+- Applying a canvas preset rewrote native Photo Booth lighting properties, including native sun position, intensity, and color.
+- The custom DirectionalLight, target, custom group, shadow map, and `castShadow` state remained present in the later diagnostic report.
+- The custom shadow matrix nevertheless stopped following light movement.
+
+Current interpretation:
+
+- Canvas presets are a confirmed confounding factor because they trigger broader Photo Booth lighting-state updates.
+- They are not proven to delete or disable the custom light.
+- They may leave the custom shadow projection stale or bypass its refresh path.
+
+### Persistent Booth / Witch Dock
+
+Current status:
+
+- Persistent Booth remains live/working and must not be modified as part of this lighting investigation.
+- A compatibility test with Witch Dock coincided with shadows no longer appearing, but the test also involved a canvas preset and later state changes.
+- No report proves that Witch Dock or Persistent Booth permanently disabled custom shadows.
+
+Rule:
+
+- Do not attribute the shadow regression to Witch Dock without an isolated A/B test.
+- Test probe-only, then probe + Witch Dock with no preset change, then preset change as a separate variable.
+- Do not edit `tools/Booth.js` unless a concrete, isolated compatibility regression is demonstrated.
+
+## Third SphereLight
+
+### Confirmed Renderer Registration
+
+The injected custom SphereLight:
+
+- remained attached and visible in scene snapshots;
+- had its own UUID and custom color/intensity/distance;
+- increased material `numSphereLights` counts;
+- continued to be counted when both native orb lights were manually disabled.
+
+During the isolation test:
+
+- two native lights + custom produced `numSphereLights: 3`;
+- one native light + custom produced `numSphereLights: 2`;
+- zero native lights + custom produced `numSphereLights: 1`.
+
+Important correction:
+
+- The native count reductions were caused by the user manually turning off native orb lights for isolation.
+- Do not describe that count change as HeroForge lifecycle removal.
+
+### Confirmed Visible Failure
+
+Observed by the user:
+
+- With both native orb lights disabled, the custom SphereLight was the sole registered SphereLight but still produced no visible illumination.
+
+This rules out:
+
+- a hard maximum of two sphere lights;
+- third-position/order alone;
+- masking by native orb lights;
+- failure to attach;
+- failure to be counted by materials;
+- the sibling group as a general scene-discovery failure.
+
+Current inference:
+
+- The custom SphereLight is missing a SphereLight-specific registration, occlusion, slot binding, or live uniform path.
+
+Relevant native occlusion fields observed:
+
+- `CK.character.children[0].partLightOcclusion0`
+- `CK.character.children[0].partLightOcclusion1`
+
+The exact suppressing mechanism remains unproven.
+
+Rule:
+
+- Do not claim the third SphereLight is working because the material count increments.
+- `numSphereLights` proves shader configuration/counting, not valid visible contribution.
+- Leave the SphereLight path separate while DirectionalLight stabilization is the active priority.
+
+## Future Camera-Relative Rim Lighting
+
+### Queue Position
+
+This work begins after DirectionalLight movement, target, shadow-refresh, and lifecycle behavior are stable enough to stop changing the physical-light foundation.
+
+### Goal
+
+Create a rim-only or rim-weighted effect that:
+
+- illuminates grazing-angle surfaces near the visible silhouette;
+- avoids broadly blowing out rear-facing surfaces;
+- remains camera-relative during spin capture;
+- can optionally bias the rim toward left, right, upper, or opposing colored sides.
+
+### Likely Implementation
+
+Preferred path:
+
+- Fresnel/view-angle shader contribution, probably applied through emissive or additive material output.
+
+Core form:
+
+- `rim = pow(1 - dot(normal, viewDirection), rimPower)`
+
+Potential controls:
+
+- color;
+- intensity;
+- width/power;
+- softness;
+- left/right/up directional bias;
+- optional material exclusions.
+
+### Viability Assessment
+
+Current assessment:
+
+- Basic camera-relative Fresnel rim: high viability.
+- Directionally biased Fresnel rim: high viability after the base shader hook is proven.
+- Strict outer-contour-only rim: more invasive and likely requires post-processing, depth/normal information, or an object mask.
+
+Primary unknown:
+
+- Whether HeroForge exposes a stable material/shader compile hook that can be patched without fragile bundle interception.
+
+Main risks:
+
+- HeroForge replacing materials during model, canvas, or Booth changes;
+- multiple material families using different shader paths;
+- normal/view-direction space mismatch;
+- transparent hair, glass, eyes, decals, emissive surfaces, and other special materials;
+- duplicate patch stacking when materials rebuild.
+
+Rule:
+
+- Keep Fresnel/rim lighting separate from physical DirectionalLight injection.
+- Do not present rim lighting as another ordinary light type.
+- Start with a read-only shader-hook probe before active shader mutation.
+
+## Next Investigation Order
+
+1. Reproduce the successful v0.3 shadow run with only the probe enabled and no canvas preset changes.
+2. Move the light once and determine the exact moment the custom shadow matrix stops updating.
+3. Probe renderer/shadow invalidation and native sun shadow-refresh calls.
+4. Add one explicit custom-shadow refresh action at a time.
+5. Retest editor, Photo Booth, canvas preset changes, and normal mode transitions.
+6. Run an isolated probe + Witch Dock compatibility test without changing presets.
+7. Only after the DirectionalLight path is stable, begin the read-only shader-hook/rim-light probe.
+
+## Do Not Repeat
+
+- Do not infer visible contribution solely from material light counts.
+- Do not use `numDirLightShadows` as the only shadow-success signal.
+- Do not toggle shadows after attachment and assume that matches the working pre-attach path.
+- Do not call the custom DirectionalLight a second sun.
+- Do not hard-code runtime UUIDs or a single numeric scene path.
+- Do not blame Witch Dock or Persistent Booth without an isolated test.
+- Do not mix Fresnel rim-lighting work into the physical DirectionalLight probe.
+- Do not modify Persistent Booth merely because lighting is tested inside Photo Booth.

--- a/HISTORY/Bullshit_Bible.md
+++ b/HISTORY/Bullshit_Bible.md
@@ -15,6 +15,10 @@ Use this file for high-level rules and links. Put detailed notes in `HISTORY/BUL
 - Do not treat HeroForge UI layout as stable. The same UI can present as right-side grouped, split side-by-side, or bottom compact layout.
 - Do not assume Photo Booth output is normal DOM/CSS. The booth frame/effects can be baked into the WebGL render path.
 - Persistent Booth is live/working. Do not put it back on the open PNG-capture todo list.
+- Repository documentation is the durable project memory. Do not leave validated findings, corrections, status changes, or material probe milestones only in chat.
+- Use documentation checkpoints after meaningful validated results. Do not create a commit for every trivial repeated observation, but do not begin the next material probe/code stage while current docs are knowingly stale.
+- When a finding is disproved or becomes outdated, correct or remove the old claim instead of appending a contradictory active claim elsewhere.
+- Label uncertain conclusions as observed, inferred, or unproven. Do not promote inference to confirmed behavior without evidence.
 
 ## High-Risk Current Topics
 
@@ -42,6 +46,29 @@ Current status:
 - Intended first target is conservative: 1024x1024, around 72 PNG frames, ZIP output, metadata, explicit arming, and validated frame dimensions.
 - Prior probes captured useful signals but not a finished reliable pipeline.
 
+### Advanced Lighting / Shadows
+
+Detailed notes live in:
+- `BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `BULLSHIT/TIMING_AND_STATE.md`
+- `BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `../STANDALONE_REFERENCES.md`
+
+Current status:
+- A second custom DirectionalLight is confirmed working for visible illumination, position, and intensity.
+- Independent custom DirectionalLight shadow allocation is confirmed in Photo Booth when shadows are enabled before first attachment.
+- Shadow refresh after later movement or broader Photo Booth/canvas changes is unresolved; the shadow matrix can remain stale.
+- A third custom SphereLight is counted by materials but does not visibly illuminate.
+- Camera-relative Fresnel/rim lighting is queued after DirectionalLight stabilization.
+- This is standalone probe work, not a live Witch Dock module.
+
+Current rules:
+- Do not call the custom DirectionalLight a second sun.
+- Do not infer visible light contribution from material counts alone.
+- Do not use `numDirLightShadows` as the sole shadow-success signal.
+- Do not blame or modify Persistent Booth without an isolated compatibility regression.
+- Keep physical DirectionalLight injection separate from future shader-based rim lighting.
+
 ### Standalone / External References
 
 Detailed notes live in:
@@ -59,6 +86,7 @@ Current rule:
 - `BULLSHIT/DECALS_AND_TEXTURES.md`
 - `BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
 - `BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
+- `BULLSHIT/LIGHTING_AND_SHADOWS.md`
 - `BULLSHIT/KITBASHING_AND_BONES.md`
 - `BULLSHIT/JSON_AND_LIBRARY.md`
 - `BULLSHIT/MANIFEST_AND_LOADING.md`
@@ -68,3 +96,4 @@ Current rule:
 - Backfill any remaining PNG-series capture probes if new details surface.
 - Document current bone detection timing/path behavior in deeper detail.
 - Recover and inventory remaining standalone migration candidates in `HISTORY/STANDALONE_REFERENCES.md`.
+- Keep lighting/shadow documentation synchronized with each material probe milestone and correction.

--- a/HISTORY/DECISIONS.md
+++ b/HISTORY/DECISIONS.md
@@ -4,6 +4,49 @@ Durable decisions that should guide future repo work.
 
 ## Active Decisions
 
+### 2026-07-12 — Documentation Checkpoints Are Required During Investigation
+
+Decision:
+- Treat repository documentation as the durable project memory, not chat history.
+- Update the relevant tracking/history files after meaningful validated findings, corrections, status changes, architecture decisions, blockers, canonical-reference changes, or material probe milestones.
+- Batch closely related low-level observations rather than committing every repeated test action.
+- Do not begin the next material probe/code stage while the current docs are knowingly stale.
+- Correct or remove outdated active claims instead of leaving contradictory statements in place.
+
+Reason:
+- Chat/model memory is not reliable enough to preserve fragile HeroForge findings across OpenAI updates, context resets, or future development sessions.
+- Milestone-based checkpoints preserve critical state without creating noise from every minor test click.
+
+Applies to:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/SESSION_LOG.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- relevant `HISTORY/BULLSHIT/` topic files
+- all standalone probe and migration work
+
+### 2026-07-12 — Physical Lighting, Rim Lighting, and Persistent Booth Stay Separate
+
+Decision:
+- Keep custom physical DirectionalLight/SphereLight work separate from future Fresnel/shader-based rim lighting.
+- Keep advanced lighting investigation separate from Persistent Booth implementation.
+- Do not modify `tools/Booth.js` for lighting unless an isolated compatibility regression proves a concrete integration requirement.
+- Treat `HeroForge_Lighting_Injection_Probe_v0.3.0.txt` as the current partial working reference for pre-attach DirectionalLight shadows until a later probe is validated.
+
+Reason:
+- Physical lights, shadow maps, and view-dependent rim shading use different renderer paths and failure modes.
+- Persistent Booth is already live/working, while the lighting probes are standalone and unresolved.
+- The current compatibility regression was confounded by canvas-preset changes and does not prove Witch Dock or Persistent Booth caused shadow failure.
+
+Applies to:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- future lighting tools/modules
+- future shader/rim-light probe
+- `tools/Booth.js`
+
 ### 2026-07-09 — Witch Dock Documentation Structure
 
 Decision:

--- a/HISTORY/README.md
+++ b/HISTORY/README.md
@@ -1,6 +1,6 @@
 # History
 
-This folder stores project memory that should survive chat boundaries.
+This folder stores durable project memory that should survive chat boundaries, context resets, model updates, and future development sessions.
 
 ## Files
 
@@ -8,6 +8,14 @@ This folder stores project memory that should survive chat boundaries.
 - `DECISIONS.md`: durable project decisions and why they were made.
 - `STANDALONE_REFERENCES.md`: inventory of standalone scripts, external references, probes, deprecated scripts, and migration status.
 - `Bullshit_Bible.md`: index of HeroForge engine weirdness and fragile rules.
-- `BULLSHIT/`: topic-specific notes for recurring HeroForge behavior problems.
+- `BULLSHIT/`: topic-specific notes for recurring HeroForge behavior problems, including `LIGHTING_AND_SHADOWS.md` for the advanced-lighting investigation.
 
-Keep entries concise. The goal is fast recovery, not archival noise.
+## Documentation Checkpoints
+
+- Update the relevant files after meaningful validated findings, corrections, status changes, decisions, blockers, canonical-reference changes, or material probe milestones.
+- Batch trivial repeated observations rather than logging every test click.
+- Do not begin the next material probe/code stage while the current docs are knowingly stale.
+- Correct or remove outdated active claims instead of appending contradictory active statements.
+- Distinguish confirmed behavior from observations, inferences, and unproven hypotheses.
+
+Keep entries concise enough for fast recovery, but complete enough that critical project state does not depend on chat memory.

--- a/HISTORY/SESSION_LOG.md
+++ b/HISTORY/SESSION_LOG.md
@@ -2,6 +2,14 @@
 
 Chronological development and testing notes. Use this for concise project-state updates that matter across chats.
 
+## 2026-07-12 — Advanced Lighting Investigation Checkpoint
+
+- Target: persist the current HeroForge custom-light investigation and close the documentation gap that left validated probe findings only in chat.
+- Action: added `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`; inventoried Lighting Probe v0.1.0 and Injection Probe v0.1.0-v0.3.0; updated `MASTER.md`, `HISTORY/Bullshit_Bible.md`, `HISTORY/STANDALONE_REFERENCES.md`, and `HISTORY/DECISIONS.md`; added a milestone-based documentation-checkpoint rule.
+- Result: repo memory now records the working second DirectionalLight, position/intensity behavior, Photo Booth pre-attach shadow allocation, editor/Photo Booth targeting difference, stale shadow-matrix regression, non-working but counted third SphereLight, canvas-preset confounder, Persistent Booth separation, and queued Fresnel/rim-light investigation.
+- Test notes: documentation-only update; no JavaScript, userscript metadata, `manifest.json`, storage keys, UI, or runtime behavior changed.
+- Follow-up: stabilize custom DirectionalLight shadow refresh/lifecycle behavior with standalone probes. After that, begin a read-only shader-hook probe for camera-relative Fresnel rim lighting.
+
 ## 2026-07-09 — Standalone Reference Inventory Backfill
 
 - Target: standalone scripts, external references, probes, deprecated scripts, and migration status.

--- a/HISTORY/STANDALONE_REFERENCES.md
+++ b/HISTORY/STANDALONE_REFERENCES.md
@@ -9,8 +9,10 @@ Use this file to prevent rehashing old investigations and to separate canonical 
 | Status | Meaning |
 |---|---|
 | External canonical reference | Working external/user-provided script that Witch Dock may depend on or compare against. Do not reinterpret without direct comparison. |
+| Standalone canonical | Working standalone probe/reference that must be preserved until migration is tested and confirmed. |
 | Historical diagnostic reference | Old standalone version/probe that explains a bug/regression but is not current live code. |
 | Unresolved probe | Useful investigation code or behavior notes, but no confirmed finished implementation. |
+| Queued / unproven | Defined follow-up investigation that has not yet produced an active proof-of-concept. |
 | Deprecated | Old script should not be used with current Witch Dock unless explicitly resurrected for comparison. |
 | Migrated / absorbed | Behavior has been moved into Witch Dock or current docs; keep reference only for regression history. |
 | Needs recovery | Known or likely reference exists, but details still need old-chat/source recovery. |
@@ -42,6 +44,129 @@ Related files:
 - `HeroForge_UI/Expanded_Decal_Slots.js`
 - `tools/Utilities.js`
 - `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
+
+### HeroForge Lighting Probe v0.1.0
+
+Status:
+- Read-only unresolved probe / canonical diagnostic reference.
+
+Files:
+- `HeroForge_Lighting_Probe_v0.1.0.txt`
+- `HeroForge_Lighting_Probe_v0.1.0_diff.txt`
+
+Current source state:
+- Developed and tested as standalone Tampermonkey probe files outside the live repository modules.
+- Probe source is not currently stored as a live Witch Dock module.
+
+Known behavior / relevance:
+- Scans HeroForge globals, object graphs, light constructors, active lighting roots, material light counts, and bundle support.
+- Identified `CK.environment.lighting`, native `sunlight`, native `_partLightGroup`, SphereLight instances, and dynamic renderer support for several light families.
+- Exports diagnostic JSON without intentionally mutating the scene.
+
+Rules:
+- Preserve this probe as read-only.
+- Do not turn it into the injection test harness.
+- Use tolerant scene/object discovery rather than hard-coded child indexes or UUIDs.
+
+Related files:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+
+### HeroForge Lighting Injection Probe v0.1.0
+
+Status:
+- Historical diagnostic reference / partial success.
+
+Files:
+- `HeroForge_Lighting_Injection_Probe_v0.1.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.1.0_diff.txt`
+
+Known behavior / relevance:
+- Established tolerant active-rig discovery, custom owned-group attachment, cleanup, report export, and lifecycle monitoring.
+- Confirmed a second non-shadow DirectionalLight can visibly illuminate the figure.
+- Confirmed a third SphereLight can be counted by material light configuration while still producing no visible illumination.
+
+Rules:
+- Preserve the working DirectionalLight injection path when extending later probes.
+- Do not interpret material light counts as proof of visible light contribution.
+- Do not dispose cloned/shared resources during cleanup.
+
+Related files:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+
+### HeroForge Lighting Injection Probe v0.2.0
+
+Status:
+- Historical diagnostic reference / transform and post-attach-shadow control probe.
+
+Files:
+- `HeroForge_Lighting_Injection_Probe_v0.2.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.2.0_diff.txt`
+
+Known behavior / relevance:
+- Added DirectionalLight position, target, intensity, post-attachment shadow toggle, and expanded matrix/shadow diagnostics.
+- Position and intensity controls worked in editor and Photo Booth.
+- Target changes visibly affected Photo Booth but not the editor during that test.
+- Enabling shadows after attachment was not the reliable working path.
+
+Rules:
+- Retain as the control/reference for post-attachment shadow failure.
+- Do not replace the later pre-attach-shadow path with this toggle-only path.
+
+Related files:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+
+### HeroForge Lighting Injection Probe v0.3.0
+
+Status:
+- Standalone canonical / partial working reference.
+- Current active lighting injection probe.
+
+Files:
+- `HeroForge_Lighting_Injection_Probe_v0.3.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.3.0_diff.txt`
+
+Known behavior / relevance:
+- Preserves working DirectionalLight illumination, position, intensity, target, report, lifecycle, and cleanup behavior.
+- Adds a pre-attachment shadow path with `castShadow: true` before first scene attachment.
+- Photo Booth allocated an independent custom shadow map and calculated matrix in a successful test.
+- The same custom light, target, and group persisted through the successful lifecycle test.
+- A later test retained the map and `castShadow` state, but the shadow matrix remained stale after the light moved.
+- Controlled detach/re-attach did not force a matrix refresh.
+
+Rules:
+- Treat pre-attachment shadow enablement as the current canonical shadow setup.
+- Treat Photo Booth as the confirmed custom-shadow execution environment; editor custom shadows remain unproven.
+- Do not use `numDirLightShadows` as the sole shadow-success criterion.
+- Do not claim Witch Dock or Persistent Booth caused the stale-shadow regression without isolated A/B evidence.
+- Do not migrate this probe into Witch Dock until shadow refresh/lifecycle behavior is stable.
+
+Related files:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `MASTER.md`
+
+### Camera-Relative Rim Lighting Probe
+
+Status:
+- Queued / unproven.
+
+Current source state:
+- No active script yet.
+- Planned only after physical DirectionalLight stabilization.
+
+Goal / relevance:
+- Identify a stable HeroForge shader/material hook for a camera-relative Fresnel rim effect.
+- Produce silhouette/grazing-angle illumination without broadly lighting the model's back side.
+- Support later spin-capture use where the rim remains camera-relative.
+
+Rules:
+- Begin with a read-only shader-hook probe.
+- Keep rim lighting separate from physical DirectionalLight and SphereLight injection.
+- Do not patch shader source or bundle internals until the active material compile path is identified.
+
+Related files:
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
 
 ### Photo Mode PNG Series Probe v0.7
 
@@ -217,6 +342,11 @@ Rules:
 | Reference | Status | Target | Action |
 |---|---|---|---|
 | HF Core Tweaks / Lob decal reference | External canonical reference | Maybe `HeroForge_UI/` or direct HF Core Tweaks edit, depending on final strategy | Compare before slot-expansion edits. |
+| HeroForge Lighting Probe v0.1.0 | Read-only unresolved probe | Diagnostics only | Preserve read-only; use for runtime/bundle discovery. |
+| Lighting Injection Probe v0.1.0 | Historical diagnostic reference | None directly | Preserve proof of second DirectionalLight and non-working counted SphereLight. |
+| Lighting Injection Probe v0.2.0 | Historical diagnostic reference | None directly | Preserve transform controls and post-attach-shadow control result. |
+| Lighting Injection Probe v0.3.0 | Standalone canonical / partial working reference | Future lighting subsystem after stabilization | Resolve shadow refresh/lifecycle before migration. |
+| Camera-Relative Rim Lighting Probe | Queued / unproven | Future shader/material subsystem | Start with read-only shader-hook discovery after DirectionalLight stabilization. |
 | Photo Mode PNG Series Probe v0.7 | Unresolved probe | Future visible tool or separated Booth subsection | Use as design/probe reference, not final code. |
 | Photo Booth `readPixels` probe | Unresolved probe | Future capture implementation detail | Keep as partial proof of booth pixel access. |
 | Photo Booth tokenBg hard-lock probe | Historical diagnostic reference | Booth/capture diagnostics | Use for backdrop source behavior. |

--- a/MASTER.md
+++ b/MASTER.md
@@ -22,6 +22,16 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 - Do not update `manifest.json` unless adding, removing, renaming, or changing a live-loaded module.
 - Do not update `README.md` unless install flow, public feature list, or developer documentation links change.
 
+## Documentation as Durable Project Memory
+
+- GitHub documentation is the canonical durable memory for project status, validated HeroForge findings, failed paths, corrections, and decisions.
+- Chat context is not a reliable source of truth and must not be the only place where material findings remain.
+- Create a documentation checkpoint after a meaningful validated result, correction, status change, architecture decision, blocker, canonical-reference change, or probe milestone.
+- Do not commit every repeated button click or low-value observation. Batch closely related tests, but update the docs before beginning the next material probe/code stage when current documentation is knowingly stale.
+- When evidence disproves or narrows an earlier claim, correct or remove the outdated active statement. Do not leave contradictory active claims scattered through the docs.
+- Distinguish confirmed runtime behavior from user-visible observations, supported inferences, and unproven hypotheses.
+- Documentation-only commits still require `PRE_FLIGHT_Check.md` and `CHANGELOG.md`, and must state that no JavaScript, manifest, or runtime behavior changed.
+
 ## Loading Model
 
 1. Tampermonkey installs `Witch_Dock.user.js` from the live raw URL.
@@ -58,12 +68,15 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 | HF UI | `hf-ui-scroll-split-safe` | `HeroForge_UI/HF_UI_Scroll_Split_Safe.js` | Live / hidden | Split-layout scroll override. |
 | HF UI | `hf-ui-slot-bridge` | `HeroForge_UI/HF_UI_Slot_Bridge.js` | Live / hidden | Conditional loader for expanded decal slots. |
 | HF UI | loaded by bridge | `HeroForge_UI/Expanded_Decal_Slots.js` | Live / conditional | Conditional expanded slots when compatible HF Core Tweaks data is detected. |
+| Planned | TBD | Advanced Lighting Controls | Investigating / unresolved | Standalone probes confirm a second controllable DirectionalLight and Photo Booth shadow allocation; shadow refresh and third SphereLight behavior remain unresolved. |
+| Planned | TBD | Camera-Relative Rim Lighting | Queued / unproven | Fresnel/shader-based rim effect queued after DirectionalLight stabilization. Separate from physical light injection. |
 | Planned | TBD | Photo Mode PNG Series Capture | Investigating / unresolved | High-resolution PNG sequence export from Photo Mode/photo booth while preserving HF effects/overlays. Separate from Persistent Booth. |
 | Planned | TBD | Decal Slot Swapper | Investigating / unresolved | Move/swap decals between slots without reapplying the decal, manually copying coordinates/transforms, or recoloring. Candidate target: Witch Dock panel, native Decals UI injection, or both. |
 
 ## Reference Inventories
 
 - Standalone/external/probe inventory: `HISTORY/STANDALONE_REFERENCES.md`.
+- Lighting and shadow investigation: `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`.
 - Photo Mode PNG capture feature spec: `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`.
 - HeroForge fragile behavior index: `HISTORY/Bullshit_Bible.md`.
 
@@ -171,6 +184,26 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 - Expands body upper, body lower, face, splatter font part, and egg parts.
 - Fragile area: this must remain conditional. Without the expected HF Core Tweaks signature, it must remain a no-op.
 
+### Advanced Lighting Controls — Planned / Unresolved
+
+- Not currently live in `manifest.json` or Witch Dock.
+- Dedicated history/spec file: `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`.
+- Current canonical active probe: `HeroForge_Lighting_Injection_Probe_v0.3.0.txt`.
+- Confirmed: a second custom DirectionalLight visibly renders, moves, changes intensity, and survives normal editor <-> Photo Booth transitions in standalone testing.
+- Confirmed: setting `castShadow: true` before first attachment produces an independent custom shadow map and calculated shadow matrix in Photo Booth.
+- Unresolved: the custom shadow matrix can remain stale after later movement or broader Photo Booth/canvas-state changes.
+- Unresolved: a third custom SphereLight is counted by materials but does not visibly illuminate, even when it is the only registered SphereLight.
+- Current priority: stabilize DirectionalLight shadow refresh and lifecycle behavior before Witch Dock integration.
+- Persistent Booth remains separate. Do not edit `tools/Booth.js` without an isolated compatibility regression.
+
+### Camera-Relative Rim Lighting — Queued / Unproven
+
+- Begin only after the DirectionalLight path is stable enough to stop changing the physical-light foundation.
+- Preferred path is a view-dependent Fresnel/shader contribution, not another ordinary physical light.
+- Goal: illuminate grazing-angle silhouette regions without broadly blowing out rear-facing surfaces, while remaining camera-relative during spin capture.
+- First step is a read-only shader-hook probe.
+- Keep this separate from physical DirectionalLight injection and SphereLight work.
+
 ### Decal Slot Swapper — Planned / Unresolved
 
 - Not currently live in manifest.
@@ -206,6 +239,7 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 | External canonical reference | Working external or user-provided script that must be compared before replacement or integration. |
 | Historical diagnostic reference | Old standalone version/probe that explains a bug/regression but is not current live code. |
 | Unresolved probe | Useful investigation code or behavior notes, but no confirmed finished implementation. |
+| Queued / unproven | Desired follow-up feature with a defined direction but no active proof-of-concept yet. |
 | Migrating | In progress from standalone/probe form into Witch Dock architecture. |
 | Investigating / unresolved | Known desired feature with useful probes/history but no confirmed working implementation. |
 | Blocked | Known issue prevents reliable migration or release. |
@@ -213,9 +247,12 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 
 ## Active Tasks
 
+- Keep repository documentation synchronized at material probe/code milestones; do not leave validated findings or corrections only in chat.
 - Backfill project history from previous chats.
-- Keep `HISTORY/STANDALONE_REFERENCES.md` current as standalone/probe sources are recovered.
+- Keep `HISTORY/STANDALONE_REFERENCES.md` current as standalone/probe sources are recovered or created.
 - Fill `HISTORY/BULLSHIT/` topic files with durable HeroForge engine discoveries.
+- Stabilize custom DirectionalLight shadow refresh and lifecycle behavior using the standalone lighting probes.
+- After DirectionalLight stabilization, run a read-only shader-hook probe for camera-relative Fresnel/rim lighting.
 - Add deeper old-chat recovery notes for Booth minor fixes/effects edge cases, bones/kitbashing, JSON/library, and remaining standalone references.
 - Investigate Photo Mode PNG Series Capture using existing probe history and the dedicated feature spec before writing new implementation.
 - Investigate Decal Slot Swapper implementation paths for Witch Dock control, native Decals UI injection, or both.
@@ -227,6 +264,8 @@ Add standalone scripts here when they are ready to migrate into Witch Dock. Deta
 | Tool / Script | Canonical Source | Target Location | Status | Notes |
 |---|---|---|---|---|
 | HF Core Tweaks / Lob decal slot reference | External user-provided / Lob-style Tampermonkey script | TBD; maybe direct HF Core Tweaks edit or `HeroForge_UI/` bridge strategy | External canonical reference | Compare before any slot-expansion edit. Current Witch Dock expansion depends on HF Core Tweaks signature and does not replace it. |
+| Advanced Lighting Controls | `HeroForge_Lighting_Probe_v0.1.0.txt` and Injection Probe v0.1.0-v0.3.0 | TBD; future `/tools/` lighting panel plus isolated runtime helper if proven stable | Investigating / unresolved | Second DirectionalLight works; Photo Booth pre-attach shadow allocation works; shadow refresh and third SphereLight remain unresolved. Do not migrate until lifecycle behavior is stable. |
+| Camera-Relative Rim Lighting | Future read-only shader-hook probe | TBD; separate shader/material subsystem | Queued / unproven | Fresnel rim queued after DirectionalLight stabilization. Do not fold into physical-light injection. |
 | Decal Slot Swapper | New feature investigation / future probes | TBD, likely `/tools/` plus optional `/HeroForge_UI/` native Decals UI injection | Investigating / unresolved | Move/swap decal data between slots while preserving placement/transforms, color/material data, source/projection target, and undo/redo integration. |
 | Photo Mode PNG Series Capture | Prior standalone probes / old-chat history + `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md` | TBD, likely `/tools/` or clearly separated Booth subsection | Investigating / unresolved | First target should be 1024x1024, around 72 PNG frames, ZIP output, metadata, explicit arming, validated dimensions, and preserved Photo Booth effects. Persistent Booth is separate and already working. |
 | Booth v12/v13 standalone history | Prior standalone Booth scripts | None unless diagnosing a Booth regression | Historical diagnostic reference | Use only for future Booth persistence/effects regression diagnosis. Persistent Booth is currently live/working. |
@@ -242,8 +281,10 @@ Add standalone scripts here when they are ready to migrate into Witch Dock. Deta
 - Tools that rely on HeroForge internal state must preserve known-good timing, retry, snapshot, mutation, and probing behavior.
 - Working standalone scripts remain canonical until the integrated Witch Dock version is tested and confirmed.
 - Presentation is frozen unless UI/UX changes are explicitly requested.
-- Booth, Decals, bone detection, and JSON/library workflows have the highest fragility and need old-chat recovery before major changes.
-- Persistent Booth is live/working. Do not classify it as an open PNG-series capture task.
+- Booth, Decals, bone detection, JSON/library, and custom lighting workflows are high-fragility areas.
+- Persistent Booth is live/working. Do not classify it as an open PNG-series capture task or modify it for lighting without isolated evidence.
+- Custom DirectionalLight shadow allocation is Photo Booth-specific in current tests, and the shadow matrix can become stale after later movement/state changes.
+- A third SphereLight being counted by materials does not mean it contributes visible illumination.
 - PNG series capture is not solved; avoid assumptions about 512x512 limits, DOM/CSS booth frame control, hidden HDR/16-bit buffer access, or large ZIP reliability.
 - High-resolution PNG sequences may stress browser memory/download behavior; start at 1024 before scaling to 2048/4K.
 
@@ -257,3 +298,5 @@ Document removed, deprecated, or rejected work here with the reason.
 | Global raw `#menuC` / `#menuD` Decals scroll styling | Rejected | HeroForge reuses these containers; global styling caused empty resize zones and does not handle all Decals layouts safely. | 2026-07-09 |
 | Treating Photo Booth frame as only DOM/CSS | Rejected | Prior probing found the 1:1 booth frame can be baked into the WebGL scene; export pixels must be verified directly. | 2026-07-09 |
 | Treating Persistent Booth as unfinished PNG-capture work | Rejected | Persistent Booth is live/working; PNG Series Capture is a separate planned/export feature. | 2026-07-09 |
+| Treating material light counts as proof of visible illumination | Rejected | The third SphereLight increments `numSphereLights` but does not visibly illuminate even when it is the only registered SphereLight. | 2026-07-12 |
+| Treating `numDirLightShadows` as the sole Photo Booth shadow-success signal | Rejected | Visible custom shadows and an allocated independent map were observed while the inspected counter remained `0`. | 2026-07-12 |

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -9,6 +9,7 @@ Time: 14:08 PDT
 
 Target files:
 - `MASTER.md`
+- `HISTORY/README.md`
 - `HISTORY/Bullshit_Bible.md`
 - `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
 - `HISTORY/STANDALONE_REFERENCES.md`
@@ -21,6 +22,7 @@ Relevant history checked:
 - `MASTER.md`
 - `PRE_FLIGHT_Check.md`
 - `CHANGELOG.md`
+- `HISTORY/README.md`
 - `HISTORY/Bullshit_Bible.md`
 - `HISTORY/STANDALONE_REFERENCES.md`
 - `HISTORY/DECISIONS.md`

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -2,6 +2,59 @@
 
 Use this file before repo updates to record what was checked, what could conflict, and what action is recommended.
 
+## PFC-2026-07-12-008 — Advanced Lighting Documentation Checkpoint
+
+Date: 2026-07-12
+Time: 14:08 PDT
+
+Target files:
+- `MASTER.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_SHADOWS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+Relevant history checked:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- current standalone probe sources: `HeroForge_Lighting_Probe_v0.1.0.txt`, `HeroForge_Lighting_Injection_Probe_v0.1.0.txt`, `HeroForge_Lighting_Injection_Probe_v0.2.0.txt`, and `HeroForge_Lighting_Injection_Probe_v0.3.0.txt`
+- current diagnostic reports for Injection Probe v0.1.0, v0.2.0, and v0.3.0
+- current user corrections: native SphereLight count changes were manual isolation toggles; Persistent Booth is not to be modified; Witch Dock is not proven to have caused the later shadow regression
+
+Connected modules reviewed:
+- `tools/Booth.js` documentation and known runtime responsibilities through `MASTER.md` and `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `manifest.json` loading rules through `MASTER.md`; no manifest change required
+- standalone probe lifecycle, custom object ownership, attachment path, target handling, shadow setup, cleanup, and report behavior
+
+Conflict risks:
+- No JavaScript files changed.
+- No userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, or runtime behavior changed.
+- Lighting probes remain standalone and unresolved; documentation must not classify them as live Witch Dock modules.
+- A second DirectionalLight is confirmed working, but shadow refresh remains unresolved.
+- A third SphereLight is counted but not visibly working; material counts must not be presented as proof of visible illumination.
+- The later shadow failure involved both Witch Dock compatibility testing and a canvas preset; do not attribute causation to Witch Dock or Persistent Booth without isolated evidence.
+- Persistent Booth remains live/working and separate from advanced lighting development.
+- Fresnel/rim lighting is queued only; no shader hook has been proven.
+
+Recommended action:
+- Proceed with a documentation-only checkpoint.
+- Add a dedicated lighting/shadow history file and inventory the standalone probes.
+- Add a durable rule requiring documentation checkpoints after meaningful validated findings, corrections, status changes, decisions, blockers, or probe milestones.
+- Batch trivial repeated observations, but update docs before starting the next material probe/code stage when current documentation is knowingly stale.
+- Continue DirectionalLight shadow-refresh diagnosis in standalone probes before any Witch Dock migration.
+
 ## PFC-2026-07-09-007 — Standalone Reference Inventory Backfill
 
 Date: 2026-07-09


### PR DESCRIPTION
## Summary

- Adds durable documentation for the HeroForge advanced-lighting investigation.
- Inventories Lighting Probe v0.1.0 and Injection Probe v0.1.0-v0.3.0.
- Records confirmed DirectionalLight behavior, Photo Booth pre-attach shadow allocation, stale shadow-matrix regression, counted-but-inactive third SphereLight, and queued Fresnel rim lighting.
- Adds milestone-based documentation checkpoint rules so validated findings and corrections are not left only in chat.

## Scope

Documentation only. No JavaScript, userscript probe, manifest, storage, UI, or runtime changes.