### PR TITLE
Document Advanced Lighting Probe v0.6 results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## DOCS-2026-07-14-010 — Advanced Lighting Probe v0.6 Static Shadow Texture Correction
+
+Date: 2026-07-14
+Time: 16:40 PDT
+
+### Changed
+
+- Updated `MASTER.md` with the validated v0.6 result, corrected shadow-path status, revised active tasks, migration notes, watch items, and rejected assumptions.
+- Updated `HISTORY/Bullshit_Bible.md` with the v0.6 correction that the traced `additionalSunShadowMap` textures are static environment-shadow image assets rather than the dynamic native sun-shadow path.
+- Updated `HISTORY/STANDALONE_REFERENCES.md` to mark Injection Probe v0.6.0 as a completed diagnostic correction milestone and record the exact static texture assets it identified.
+- Updated `HISTORY/SESSION_LOG.md` with the controlled v0.6 test sequence, results, correction, and next investigation target.
+- Updated `PRE_FLIGHT_Check.md` with the v0.6 result checkpoint, connected systems reviewed, conflict risks, and recommended next action.
+
+### Confirmed / Corrected Documentation
+
+- Confirmed the two traced `additionalSunShadowMap` textures are ordinary 512x512 `HTMLImageElement`-backed textures loaded from `summonCircle_shadow_512.webp` and `foliage_shadow_512.webp`.
+- Confirmed those texture UUIDs, versions, dimensions, asset paths, and material bindings remained unchanged through baseline -> native-sun override -> restore.
+- Confirmed the native `sun.shadow.map`, native shadow matrix, material shadow states, detailed bindings, resource trace, and captured texture-diagnostic structures also remained unchanged while the native sun position/intensity/color changed and then returned to baseline.
+- Corrected the earlier working hypothesis that the traced `additionalSunShadowMap` resources might be the dynamic visible native sun-shadow textures.
+- Recorded the strong current inference that direct native-sun mutation changes visible illumination without regenerating the native shadow projection/map; restoring the original sun transform realigns the unchanged shadow data, explaining why visible shadows return without a captured shadow-resource change.
+- Recorded that the next focused Shadow Pipeline Probe should target the actual native `sun.shadow` update/render lifecycle and legitimate HeroForge lighting-state transitions.
+
+### Touched Files
+
+- `MASTER.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+### Rollback Notes
+
+- Documentation-only checkpoint and correction.
+- No JavaScript files changed.
+- No standalone userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- Rolling back would restore the superseded interpretation that the traced `additionalSunShadowMap` textures might be part of the unresolved dynamic native sun-shadow pipeline.
+
+### Test Notes
+
+- Runtime evidence came from `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json`.
+- Controlled sequence: enter Photo Booth with native shadows visible, inject the custom DirectionalLight with pre-attach shadows, run only the native-sun shadow comparison round, and download the report.
+- Probe report contained no recorded errors.
+- No Witch Dock or Persistent Booth runtime test was part of this checkpoint.
+
 ## DOCS-2026-07-13-009 — Advanced Lighting v0.4-v0.6 Documentation Correction
 
 Date: 2026-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Time: 16:40 PDT
 
 - Updated `MASTER.md` with the validated v0.6 result, corrected shadow-path status, revised active tasks, migration notes, watch items, and rejected assumptions.
 - Updated `HISTORY/Bullshit_Bible.md` with the v0.6 correction that the traced `additionalSunShadowMap` textures are static environment-shadow image assets rather than the dynamic native sun-shadow path.
+- Updated `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md` with the complete v0.6 controlled-test result, corrected `additionalSunShadowMap` interpretation, revised shadow-pipeline diagnosis, probe-split scope, and next investigation order.
 - Updated `HISTORY/STANDALONE_REFERENCES.md` to mark Injection Probe v0.6.0 as a completed diagnostic correction milestone and record the exact static texture assets it identified.
 - Updated `HISTORY/SESSION_LOG.md` with the controlled v0.6 test sequence, results, correction, and next investigation target.
 - Updated `PRE_FLIGHT_Check.md` with the v0.6 result checkpoint, connected systems reviewed, conflict risks, and recommended next action.
@@ -26,6 +27,7 @@ Time: 16:40 PDT
 
 - `MASTER.md`
 - `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
 - `HISTORY/STANDALONE_REFERENCES.md`
 - `HISTORY/SESSION_LOG.md`
 - `PRE_FLIGHT_Check.md`
@@ -130,7 +132,7 @@ Time: 14:08 PDT
 ### Confirmed / Corrected Documentation
 
 - Confirmed a second custom DirectionalLight visibly renders and supports position and intensity changes.
-- Confirmed pre-attachment `castShadow: true` can allocate an independent custom shadow map and calculated matrix in Photo Booth.
+- Confirmed pre-attachment `castShadow: true` can allocate an independent custom shadow map and calculated shadow matrix in Photo Booth.
 - Documented the unresolved stale-shadow-matrix behavior after later movement/state changes.
 - Corrected the earlier assumption that `numDirLightShadows` must become `1`; visible custom shadows and an allocated map were observed while the inspected value remained `0`.
 - Corrected native SphereLight count interpretation: count reductions in the isolation test were caused by manual user toggles, not HeroForge lifecycle removal.

--- a/HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md
+++ b/HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md
@@ -39,7 +39,7 @@ Current desired capability set:
 - target/aim controls;
 - intensity controls;
 - color controls;
-- reliable shadow behavior if HeroForge's shadow pipeline can be safely extended;
+- reliable shadow behavior if HeroForge's actual shadow pipeline can be safely extended;
 - later investigation of additional light families where practical;
 - later camera-relative rim lighting as a separate shader/material path.
 
@@ -71,8 +71,10 @@ Includes:
 - native sun shadow behavior;
 - generic DirectionalLight shadow objects;
 - Photo Booth shadow allocation;
-- `additionalSunShadowMap` resources;
-- renderer-owned shadow refresh/update paths.
+- actual native `sun.shadow` update/render lifecycle;
+- legitimate HeroForge lighting-state transitions that refresh shadow data.
+
+The `additionalSunShadowMap` branch is no longer the active dynamic-shadow target. Probe v0.6 identified the traced resources as static environment-shadow image assets.
 
 ### Camera-Relative Rim Lighting
 
@@ -102,14 +104,18 @@ Rules:
 - HeroForge material configuration can count the custom DirectionalLight as an additional directional light.
 - A third injected SphereLight can be counted by material light configuration.
 - That third SphereLight still does not visibly illuminate, even when native orb lights are manually disabled and it is the only registered SphereLight.
-- HeroForge uses a special `additionalSunShadowMap` path on at least two `HF.summonCircle` materials.
-- Those `additionalSunShadowMap` textures are separate objects from the native `sun.shadow.map`.
-- Copying the probe DirectionalLight state onto the native HeroForge sun caused the visible native sun shadows to disappear in testing.
-- Restoring the original native sun state caused the visible sun shadows to return.
-- The same native `sun.shadow.map` object persisted through baseline -> broken override -> restored state.
-- The same two `additionalSunShadowMap` texture objects also persisted through baseline -> broken override -> restored state.
+- Copying probe DirectionalLight state onto the native HeroForge sun caused the visible native sun shadows to disappear in controlled testing.
+- Restoring the original native sun state caused the visible native sun shadows to return.
+- The native `sun.shadow.map` object and native shadow matrix remained unchanged while the sun was overridden and then restored in the v0.6 run.
+- The two previously traced `additionalSunShadowMap` textures are normal 512x512 image textures loaded from:
+  - `/static/herobundles/background/summonCircle/summonCircle_shadow_512.webp?2=pv`
+  - `/static/herobundles/background/foliage/foliage_shadow_512.webp?2=pv`
+- Those two textures remained ordinary `HTMLImageElement`-backed textures with stable UUIDs, version `1`, dimensions, asset paths, and material bindings through baseline -> override -> restore.
+- Material shadow states, detailed bindings, traced resource identities, and captured texture-diagnostic structures were unchanged through the same v0.6 comparison sequence.
 
 ### Corrected / No Longer Claimed
+
+#### Independent custom DirectionalLight shadows
 
 The earlier v0.3 result was initially treated as proof that an independent custom DirectionalLight produced visible custom shadows.
 
@@ -128,11 +134,51 @@ Current rule:
 - visible independent custom DirectionalLight shadowing remains unproven and currently appears non-working;
 - do not describe the v0.3 run as a solved shadow implementation.
 
+#### `additionalSunShadowMap` as the dynamic native sun-shadow path
+
+The v0.4-v0.5 branch treated the two `additionalSunShadowMap` resources as possible dynamic native sun-shadow textures because:
+
+- they were bound to materials with `additionalSunShadow: true`;
+- they were separate from `sun.shadow.map`;
+- their identities persisted while visible native shadow state changed.
+
+Probe v0.6 corrected that interpretation.
+
+The traced resources are ordinary static environment-shadow image textures for the summon circle and foliage. They are not renderer-owned dynamic sun-shadow render targets.
+
+Current rule:
+
+- do not continue the dynamic sun-shadow investigation through those two `additionalSunShadowMap` textures;
+- do not infer resource purpose from the uniform name alone;
+- inspect the actual asset path, resource type, source, and backing object before classifying a shadow-related uniform.
+
+### Strong Current Inference
+
+The v0.6 comparison produced a simpler explanation for the native shadow loss/recovery:
+
+1. Native sun begins at its normal transform with visible shadows.
+2. The probe directly changes native sun position, target, intensity, and color.
+3. Visible illumination changes.
+4. The captured native `sun.shadow.map` and shadow matrix do not change.
+5. Visible shadows disappear.
+6. The probe restores the original native sun transform/state.
+7. The same unchanged native shadow data is spatially valid again and visible shadows return.
+
+Strong inference:
+
+- direct native-sun mutation changes lighting without triggering the shadow refresh/update path;
+- the shadow data remains calculated for the original sun state;
+- moving the sun makes that shadow projection/map stale or spatially mismatched;
+- restoring the original sun state realigns the light with the unchanged shadow data.
+
+This is not yet direct proof of the exact renderer method or HeroForge controller that performs a legitimate shadow refresh.
+
 ### Unresolved
 
-- The actual HeroForge update routine that regenerates or validates visible sun shadows.
-- Whether `additionalSunShadowMap` texture contents are rerendered in place while object identity remains stable.
-- Whether a stable second independent shadow-producing DirectionalLight can be integrated without replacing the native sun path.
+- The actual HeroForge method/state transition that recalculates the native `sun.shadow` matrix and regenerates its map.
+- Which legitimate HeroForge UI or controller action triggers that refresh.
+- Whether a custom second DirectionalLight can be enrolled in that refresh/render pipeline.
+- Whether a stable second independent shadow-producing DirectionalLight is practical without shader/render-pipeline modification.
 - Why the third SphereLight is counted but visually inactive.
 - Editor-specific target refresh behavior.
 - Additional light-family viability beyond the currently tested DirectionalLight and SphereLight paths.
@@ -157,7 +203,7 @@ Purpose:
 - locate active lighting roots;
 - inspect material light counts;
 - inspect bundle support;
-- export JSON without intentionally mutating the scene.
+- export diagnostic JSON without intentionally mutating the scene.
 
 Rule:
 
@@ -243,15 +289,15 @@ Key findings:
 - restoring the original native sun state restored visible shadows;
 - the logged native `sun.shadow.matrix` remained unchanged through the mutation/restore sequence.
 
-Interpretation:
+Historical interpretation:
 
-- directly mutating the DirectionalLight object is not sufficient to reproduce HeroForge's visible shadow-update pipeline.
+- direct DirectionalLight object mutation was not sufficient to reproduce a working moving native-shadow result.
 
 ### HeroForge Lighting Injection Probe v0.5.0
 
 Status:
 
-- Current completed shadow-resource tracing milestone.
+- Historical diagnostic reference / resource-identity tracing milestone.
 
 Added:
 
@@ -266,33 +312,55 @@ Confirmed findings:
 - direct material owners were found at:
   - `HF.summonCircle.children[0].material.uniforms.additionalSunShadowMap.value`
   - `HF.summonCircle.children[1].material.uniforms.additionalSunShadowMap.value`
-- the broad graph scan reached its `20000` node ceiling;
-- object identity and binding changes do not explain the visible shadow loss/recovery.
+- the broad graph scan reached its `20000` node ceiling.
 
-Current inference:
+Correction from v0.6:
 
-- HeroForge may rerender or rewrite the contents of persistent texture objects;
-- alternatively, a hidden renderer/controller state determines whether those persistent textures are valid/used.
+- the two traced `additionalSunShadowMap` objects were static environment-shadow image textures, so their stable identities do not describe the unresolved dynamic native sun-shadow path.
 
 ### HeroForge Lighting Injection Probe v0.6.0
 
 Status:
 
-- Current active diagnostic probe.
-- Created, not yet validated by a returned runtime report at this checkpoint.
+- Historical diagnostic reference / completed static-shadow-resource correction milestone.
 
-Purpose:
+Files:
 
-- inspect `additionalSunShadowMap` texture state;
-- inspect texture version and update state;
-- inspect source/image identity and dimensions;
-- inspect render-target/backing-resource relationships;
-- trace the texture, source, source data, and image/backing object separately;
-- compare the same working baseline -> broken override -> restored sequence.
+- `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`
+- `HeroForge_Lighting_Injection_Probe_v0.6.0_diff.txt`
+- runtime report: `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json`
 
-Rule:
+Test sequence:
 
-- do not treat v0.6.0 as a validated result until its report is reviewed.
+1. Enter Photo Booth with native sun shadows visible.
+2. Inject the custom DirectionalLight with pre-attach shadows.
+3. Make no other manual light/target/intensity/preset changes.
+4. Run the native-sun shadow comparison round.
+5. Capture baseline -> override -> restore snapshots.
+6. Download the report.
+
+Report status:
+
+- no recorded errors.
+
+Confirmed results:
+
+- custom DirectionalLight remained attached and visibly counted as a second directional light;
+- custom DirectionalLight shadow map remained null in this run;
+- native `sun.shadow.map` object remained the same;
+- native shadow matrix remained byte-for-byte unchanged;
+- material shadow-state structures remained unchanged;
+- detailed material binding structures remained unchanged;
+- traced shadow-resource identities remained unchanged;
+- two `additionalSunShadowMap` textures were identified as static 512x512 HTML image textures:
+  - summon circle shadow image;
+  - foliage shadow image;
+- their UUIDs, version `1`, dimensions, asset paths, and bindings remained unchanged through the full comparison.
+
+Conclusion:
+
+- the `additionalSunShadowMap` branch is closed for dynamic native sun-shadow diagnosis;
+- the next shadow probe must focus on the actual native `sun.shadow` update/render lifecycle.
 
 ## Runtime Lighting Structure
 
@@ -372,7 +440,7 @@ A cloned custom DirectionalLight can:
 
 Do not call it a second sun.
 
-HeroForge's native sun has additional sun-specific systems and a special visible-shadow path that are not automatically duplicated by cloning the DirectionalLight.
+HeroForge's native sun has additional shadow/update systems that are not automatically duplicated by cloning the DirectionalLight.
 
 ### Position
 
@@ -422,26 +490,42 @@ The native sun has:
 - a `sun.shadow.map` render target;
 - a calculated shadow matrix.
 
-However, visible character shadowing is not explained by that object alone.
+In the v0.6 controlled comparison:
 
-### `additionalSunShadowMap`
+- the native sun transform/intensity/color changed;
+- the native shadow-map object did not change;
+- the native shadow matrix did not change;
+- visible shadows disappeared during the override and returned after restore.
+
+This strongly indicates that direct property mutation does not trigger the native shadow refresh/update path.
+
+### `additionalSunShadowMap` — Static Environment Asset Correction
 
 At least two `HF.summonCircle` materials use:
 
 - `additionalSunShadow: true`;
 - a singular `additionalSunShadowMap` texture uniform.
 
-Important findings:
+Probe v0.6 identified the actual resources:
 
-- the two `additionalSunShadowMap` textures are distinct from `sun.shadow.map`;
-- their JavaScript object identities remained stable across working/broken/restored states;
-- their direct material uniform owner paths remained stable;
-- visible shadow state can change without replacing these texture objects.
+1. `summonCircle_shadow_512.webp`
+2. `foliage_shadow_512.webp`
 
-Current inference:
+Properties observed:
 
-- the persistent textures may be regenerated in place;
-- or another hidden state controls whether their current contents are valid/used.
+- ordinary texture objects;
+- `isTexture: true`;
+- not identified as render-target textures;
+- HTML image backing;
+- 512x512 dimensions;
+- version `1`;
+- stable asset paths and bindings.
+
+Conclusion:
+
+- these are static environment-shadow images for summon-circle/foliage rendering;
+- they are not the dynamic native sun shadow map we need to refresh;
+- the earlier `additionalSunShadowMap` investigation was a useful elimination branch but is no longer the active target.
 
 ### Native Sun Override / Restore Result
 
@@ -453,15 +537,24 @@ Observed sequence:
 4. Probe restores the original native sun state.
 5. Visible sun shadows return.
 
-Confirmed from diagnostics:
+Confirmed from v0.6 diagnostics:
 
 - the native sun object itself was not replaced;
 - `sun.shadow.map` object identity remained stable;
-- the two `additionalSunShadowMap` texture identities remained stable.
+- the native shadow matrix remained unchanged;
+- captured material shadow states and bindings remained unchanged;
+- the two traced `additionalSunShadowMap` resources were static environment images and remained unchanged.
 
-This proves that object replacement is not required for visible shadow loss/recovery.
+Strong current inference:
 
-It does not yet identify the hidden update mechanism.
+- the shadow data is stale relative to the moved sun;
+- restoring the sun returns the light to the transform for which the unchanged shadow data is valid.
+
+Next diagnostic requirement:
+
+- identify a legitimate HeroForge action that changes sun direction/position and also visibly updates shadows;
+- capture the native `sun.shadow` object before/during/after that legitimate update;
+- identify the method, controller state, renderer invalidation, or render-loop condition that changes when a real refresh occurs.
 
 ## Custom Directional Shadows
 
@@ -553,6 +646,8 @@ Current rule:
 - canvas presets are a confounding variable in lighting tests;
 - do not attribute a regression to Witch Dock when a preset changed in the same test sequence.
 
+A future focused shadow probe should treat a legitimate preset/UI lighting change as a possible source of the real native shadow-refresh call path, but only in a controlled probe where the exact changed state is captured.
+
 ### Witch Dock / Persistent Booth
 
 Current status:
@@ -573,7 +668,7 @@ Rule:
 
 The cumulative injection probe has grown too large and exposes obsolete historical actions in the Tampermonkey menu.
 
-After the v0.6 diagnostic result is reviewed, split the work into two standalone scripts.
+The v0.6 diagnostic result is now documented. The split should happen before the next material probe branch.
 
 ### 1. Lighting Injection Reference
 
@@ -603,13 +698,21 @@ Purpose:
 
 Keep only what is needed for:
 
-- native sun baseline/override/restore comparison;
-- `additionalSunShadowMap` tracing;
-- texture/source/image/backing-resource diagnostics;
-- renderer/controller lifecycle probing;
-- targeted report export.
+- native sun baseline capture;
+- controlled direct-mutation comparison when useful;
+- native `sun.shadow` map/matrix/camera state;
+- targeted renderer/controller lifecycle probing;
+- observation of legitimate HeroForge lighting changes that actually refresh visible shadows;
+- focused report export.
 
-This split should occur only after the current v0.6 result is documented so no diagnostic history is lost.
+Do not carry forward:
+
+- SphereLight injection;
+- unrelated position/intensity menus;
+- obsolete reattach experiments;
+- `additionalSunShadowMap` texture tracing as the primary dynamic-shadow target.
+
+The two static `additionalSunShadowMap` assets may remain documented as eliminated paths, but they do not need active probe controls.
 
 ## Witch Dock Migration Plan
 
@@ -618,13 +721,14 @@ Do not migrate while the physical-light foundation is still changing.
 Recommended sequence:
 
 1. Preserve a compact standalone Lighting Injection Reference.
-2. Resolve or explicitly scope the shadow limitation.
-3. Re-test the reference against current Witch Dock without modifying Persistent Booth.
-4. Define the minimum user-facing control set.
-5. Add a separate visible lighting module under `/tools/`, intended to register into the Booth tab.
-6. Add a manifest entry only when the module is ready for Witch Dock Dev testing.
-7. Test standalone reference vs Witch Dock-integrated behavior for parity.
-8. Keep shadow-pipeline code isolated from ordinary light controls where practical.
+2. Isolate the focused Shadow Pipeline Probe.
+3. Determine whether the native shadow refresh mechanism can safely support a second DirectionalLight, or explicitly scope custom shadows out.
+4. Re-test the compact injection reference against current Witch Dock without modifying Persistent Booth.
+5. Define the minimum user-facing control set.
+6. Add a separate visible lighting module under `/tools/`, intended to register into the Booth tab.
+7. Add a manifest entry only when the module is ready for Witch Dock Dev testing.
+8. Test standalone reference vs Witch Dock-integrated behavior for parity.
+9. Keep shadow-pipeline code isolated from ordinary light controls where practical.
 
 Candidate eventual module:
 
@@ -671,13 +775,14 @@ Rule:
 
 ## Current Investigation Order
 
-1. Run and analyze `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`.
-2. Determine whether the persistent `additionalSunShadowMap` textures change version/source/image/backing state across working -> broken -> restored states.
-3. Identify the renderer/controller path that refreshes or validates the visible native sun shadows.
-4. Decide whether an independent second shadow-producing DirectionalLight is realistically extendable or whether the native sun path is effectively singular.
-5. Split the cumulative probe into the compact Lighting Injection Reference and focused Shadow Pipeline Probe.
-6. Retest the compact injection reference beside Witch Dock without editing Persistent Booth.
-7. Only after physical-light behavior is stable, begin a read-only rim-light shader probe.
+1. Split the cumulative injection harness into the compact Lighting Injection Reference and focused Shadow Pipeline Probe.
+2. Preserve v0.3-era known-good second DirectionalLight injection behavior in the reference without carrying obsolete diagnostic menus forward.
+3. In the focused shadow probe, capture the actual native `sun.shadow` map/matrix/camera before and after a legitimate HeroForge lighting change that visibly updates shadows.
+4. Identify the renderer/controller method, invalidation state, or render-loop condition that changes when native shadows genuinely refresh.
+5. Test whether that same refresh path can be invoked safely after moving the custom DirectionalLight or a separately cloned shadow-casting DirectionalLight.
+6. Decide whether independent second-light shadows are realistically extendable or should be explicitly scoped out.
+7. Retest the compact injection reference beside Witch Dock without editing Persistent Booth.
+8. Only after physical-light behavior is stable, begin a read-only rim-light shader probe.
 
 ## Do Not Repeat
 
@@ -686,6 +791,8 @@ Rule:
 - Do not claim reliable visible custom DirectionalLight shadows based on the initial v0.3 visual observation.
 - Do not call the custom DirectionalLight a second sun.
 - Do not hard-code runtime UUIDs or one numeric scene path.
+- Do not infer a dynamic renderer role from a shadow-related uniform name without inspecting the actual resource type and asset source.
+- Do not continue targeting the two static `additionalSunShadowMap` image assets as the dynamic native sun-shadow path.
 - Do not blame Witch Dock or Persistent Booth without an isolated test.
 - Do not modify Persistent Booth merely because Advanced Lighting will eventually appear under the Booth tab.
 - Do not mix Fresnel rim-lighting experiments into the physical light-injection reference.

--- a/HISTORY/Bullshit_Bible.md
+++ b/HISTORY/Bullshit_Bible.md
@@ -57,11 +57,11 @@ Detailed notes live in:
 Current status:
 - A second custom DirectionalLight is confirmed working for visible illumination, position, and intensity.
 - Independent visible custom DirectionalLight shadows are not confirmed; later controlled runs did not reproduce the initial v0.3 visual result.
-- HeroForge uses separate `additionalSunShadowMap` textures on at least two `HF.summonCircle` materials rather than directly using `sun.shadow.map` as those uniforms.
+- Probe v0.6.0 confirmed the two previously traced `additionalSunShadowMap` textures are ordinary static image textures for `summonCircle_shadow_512.webp` and `foliage_shadow_512.webp`, not dynamic native sun shadow render targets.
+- The native `sun.shadow.map`, native shadow matrix, material shadow bindings, traced resource identities, and those static texture diagnostics remained unchanged while the native sun was overridden and then restored.
 - Native visible sun shadows disappeared when the native sun was overwritten with probe state and returned when the original native sun state was restored.
-- The same native sun shadow-map object and the same two `additionalSunShadowMap` texture objects persisted through working -> broken -> restored states.
+- Strong current inference: direct light mutation changes illumination without regenerating the native shadow projection/map; restoring the original sun transform realigns the unchanged native shadow data.
 - A third custom SphereLight is counted by materials but does not visibly illuminate.
-- `HeroForge_Lighting_Injection_Probe_v0.6.0.txt` is the current active diagnostic probe and has not yet been validated by a returned report at this checkpoint.
 - Camera-relative Fresnel/rim lighting is queued after the physical-light foundation stabilizes.
 - This is standalone sub-project work, not a live Witch Dock module.
 
@@ -69,6 +69,7 @@ Current rules:
 - Do not call the custom DirectionalLight a second sun.
 - Do not infer visible light contribution from material counts alone.
 - Do not treat an allocated shadow map as proof that character materials visibly consume it.
+- Do not treat `additionalSunShadowMap` as the native dynamic sun-shadow path merely because of its name; inspect the actual resource type and asset source.
 - Do not claim reliable visible custom DirectionalLight shadows from the initial v0.3 observation.
 - Do not blame or modify Persistent Booth without an isolated compatibility regression.
 - Keep physical DirectionalLight/SphereLight injection separate from future shader-based rim lighting.

--- a/HISTORY/SESSION_LOG.md
+++ b/HISTORY/SESSION_LOG.md
@@ -2,6 +2,17 @@
 
 Chronological development and testing notes. Use this for concise project-state updates that matter across chats.
 
+## 2026-07-14 — Advanced Lighting Probe v0.6 Result
+
+- Target: determine whether the two persistent `additionalSunShadowMap` textures changed internally across working baseline -> broken native-sun override -> restored native state.
+- Action: analyzed `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json` after a controlled Photo Booth run using pre-attach DirectionalLight injection followed only by the native-sun shadow comparison round.
+- Result: the two traced `additionalSunShadowMap` textures were identified as ordinary static 512x512 HTML image textures loaded from `summonCircle_shadow_512.webp` and `foliage_shadow_512.webp`. Their UUIDs, versions, image dimensions, asset paths, material bindings, and other captured backing state remained unchanged through baseline, override, and restore.
+- Result: the native `sun.shadow.map`, native shadow matrix, material shadow states, detailed bindings, shadow-resource trace, and texture-diagnostic structures also remained unchanged while the native sun position/intensity/color changed and then returned to baseline.
+- Correction: the `additionalSunShadowMap` path is not the dynamic native sun-shadow target for this investigation; the name led the earlier probe branch toward static environment shadow textures.
+- Current inference: direct mutation of the native sun changes visible illumination without regenerating the native shadow projection/map. When the sun is restored to its original transform, the unchanged shadow data is spatially valid again, explaining why visible shadows return without any logged shadow-resource change.
+- Test notes: probe runtime only; no Witch Dock, Persistent Booth, manifest, or repo JavaScript changed.
+- Follow-up: preserve the known-good second DirectionalLight injection reference, then focus the shadow probe on the actual native `sun.shadow` update/render path and the mechanism HeroForge uses to recalculate it after legitimate native lighting changes.
+
 ## 2026-07-13 — Advanced Lighting v0.4-v0.6 Documentation Checkpoint
 
 - Target: correct the stale Advanced Lighting documentation after probe work continued beyond the July 12 v0.3 checkpoint.

--- a/HISTORY/STANDALONE_REFERENCES.md
+++ b/HISTORY/STANDALONE_REFERENCES.md
@@ -187,7 +187,7 @@ Known behavior / relevance:
 
 Rules:
 - Retain as the reference for stable shadow-resource object identity across working/broken/restored states.
-- Do not interpret stable object identity as proof that texture contents or hidden renderer state are unchanged.
+- v0.6 later identified the traced `additionalSunShadowMap` resources as static environment-shadow image textures, so do not treat v0.5's stable identities as evidence about the dynamic native sun shadow path.
 
 Related files:
 - `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
@@ -195,21 +195,30 @@ Related files:
 ### HeroForge Lighting Injection Probe v0.6.0
 
 Status:
-- Current active unresolved probe.
-- Created but not yet validated by a returned runtime report at the 2026-07-13 documentation checkpoint.
+- Historical diagnostic reference / completed static-shadow-resource correction milestone.
 
 Files:
 - `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`
 - `HeroForge_Lighting_Injection_Probe_v0.6.0_diff.txt`
+- Runtime report: `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json`
 
-Purpose / relevance:
-- Target `additionalSunShadowMap` texture state and backing-resource behavior.
-- Inspect texture/source/image identity, versions, dimensions, render-target relationships, and targeted owner references.
-- Compare the same working baseline -> broken override -> restored sequence.
+Known behavior / relevance:
+- Targeted the two persistent `additionalSunShadowMap` textures and their texture/source/image/backing-resource state.
+- Confirmed the first texture was a normal 512x512 image texture loaded from `/static/herobundles/background/summonCircle/summonCircle_shadow_512.webp?2=pv`.
+- Confirmed the second texture was a normal 512x512 image texture loaded from `/static/herobundles/background/foliage/foliage_shadow_512.webp?2=pv`.
+- Both remained ordinary `HTMLImageElement`-backed textures with stable UUIDs, version `1`, dimensions, asset paths, and material bindings through baseline -> native-sun override -> restore.
+- The native `sun.shadow.map`, native shadow matrix, material shadow states, detailed bindings, shadow-resource trace, and texture-diagnostic structures also remained unchanged while the native sun position/intensity/color changed and then returned to baseline.
+- The custom probe DirectionalLight still had no allocated shadow map in this run.
+
+Correction / interpretation:
+- The traced `additionalSunShadowMap` resources are static environment-shadow image assets, not the dynamic native sun shadow map or renderer-owned shadow render targets.
+- Strong current inference: directly mutating the native sun changes visible illumination without regenerating the native shadow projection/map. Restoring the original sun transform makes the unchanged shadow data spatially valid again, explaining why visible shadows return without a captured resource change.
 
 Rules:
-- Do not treat v0.6.0 as a validated result until its report is reviewed.
-- After the v0.6 result is documented, split the cumulative harness into a compact Lighting Injection Reference and focused Shadow Pipeline Probe.
+- Preserve v0.6 as the reference that closes the `additionalSunShadowMap` branch for dynamic sun-shadow diagnosis.
+- Do not continue treating `additionalSunShadowMap` as the target for custom DirectionalLight shadow generation.
+- Split the cumulative harness before further work.
+- The next focused Shadow Pipeline Probe should target the actual native `sun.shadow` update/render lifecycle and legitimate HeroForge lighting-state transitions.
 
 Related files:
 - `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
@@ -414,9 +423,9 @@ Rules:
 | Lighting Injection Probe v0.1.0 | Historical diagnostic reference | None directly | Preserve proof of second DirectionalLight and non-working counted SphereLight. |
 | Lighting Injection Probe v0.2.0 | Historical diagnostic reference | None directly | Preserve transform controls and post-attach-shadow control result. |
 | Lighting Injection Probe v0.3.0 | Standalone canonical / partial working reference | Future Advanced Lighting subsystem after stabilization | Preserve known-good second DirectionalLight injection; do not claim solved custom shadows. |
-| Lighting Injection Probe v0.4.0 | Historical diagnostic reference | Shadow-pipeline diagnostics | Preserve native-sun takeover/restore and `additionalSunShadowMap` discovery. |
-| Lighting Injection Probe v0.5.0 | Historical diagnostic reference | Shadow-pipeline diagnostics | Preserve stable shadow-resource identity findings. |
-| Lighting Injection Probe v0.6.0 | Current active unresolved probe | Shadow-pipeline diagnostics | Validate report, document result, then split cumulative harness. |
+| Lighting Injection Probe v0.4.0 | Historical diagnostic reference | Shadow-pipeline diagnostics | Preserve native-sun takeover/restore discovery. |
+| Lighting Injection Probe v0.5.0 | Historical diagnostic reference | Shadow-pipeline diagnostics | Preserve stable resource-identity findings, but interpret them through the v0.6 static-texture correction. |
+| Lighting Injection Probe v0.6.0 | Historical diagnostic reference / completed correction milestone | Shadow-pipeline diagnostics | Closes the traced `additionalSunShadowMap` branch; split the cumulative harness and target actual native `sun.shadow` refresh/update behavior next. |
 | Camera-Relative Rim Lighting Probe | Queued / unproven | Future shader/material subsystem | Start with read-only shader-hook discovery after DirectionalLight stabilization. |
 | Photo Mode PNG Series Probe v0.7 | Unresolved probe | Future visible tool or separated Booth subsection | Use as design/probe reference, not final code. |
 | Photo Booth `readPixels` probe | Unresolved probe | Future capture implementation detail | Keep as partial proof of booth pixel access. |

--- a/MASTER.md
+++ b/MASTER.md
@@ -68,7 +68,7 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 | HF UI | `hf-ui-scroll-split-safe` | `HeroForge_UI/HF_UI_Scroll_Split_Safe.js` | Live / hidden | Split-layout scroll override. |
 | HF UI | `hf-ui-slot-bridge` | `HeroForge_UI/HF_UI_Slot_Bridge.js` | Live / hidden | Conditional loader for expanded decal slots. |
 | HF UI | loaded by bridge | `HeroForge_UI/Expanded_Decal_Slots.js` | Live / conditional | Conditional expanded slots when compatible HF Core Tweaks data is detected. |
-| Planned | TBD | Advanced Lighting / Extra Lights | Investigating / unresolved | Second custom DirectionalLight works. Independent visible custom shadows are not confirmed. Native shadow-pipeline tracing is active through Injection Probe v0.6.0; third SphereLight remains visually non-working. |
+| Planned | TBD | Advanced Lighting / Extra Lights | Investigating / unresolved | Second custom DirectionalLight works. Probe v0.6 ruled out the traced `additionalSunShadowMap` textures as the dynamic native sun-shadow path; actual native shadow refresh/update remains unresolved. Third SphereLight remains visually non-working. |
 | Planned | TBD | Camera-Relative Rim Lighting | Queued / unproven | Fresnel/shader-based rim effect queued after the physical-light foundation stabilizes. Separate from physical light injection. |
 | Planned | TBD | Photo Mode PNG Series Capture | Investigating / unresolved | High-resolution PNG sequence export from Photo Mode/photo booth while preserving HF effects/overlays. Separate from Persistent Booth. |
 | Planned | TBD | Decal Slot Swapper | Investigating / unresolved | Move/swap decals between slots without reapplying the decal, manually copying coordinates/transforms, or recoloring. Candidate target: Witch Dock panel, native Decals UI injection, or both. |
@@ -189,15 +189,16 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 - Not currently live in `manifest.json` or Witch Dock.
 - Dedicated sub-project spec and technical history: `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`.
 - Compact partial working reference for second DirectionalLight injection: `HeroForge_Lighting_Injection_Probe_v0.3.0.txt`.
-- Current active diagnostic probe: `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`; created but not yet validated by a returned report at this checkpoint.
+- Latest completed diagnostic milestone: `HeroForge_Lighting_Injection_Probe_v0.6.0.txt` with report `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json`.
 - Confirmed: a second custom DirectionalLight visibly renders, moves, changes intensity, and survives normal editor <-> Photo Booth transitions in standalone testing.
 - Corrected: reliable visible independent custom DirectionalLight shadows are not confirmed. Later controlled tests did not reproduce the initial v0.3 visual result.
-- Confirmed: HeroForge uses separate `additionalSunShadowMap` textures on at least two `HF.summonCircle` materials.
-- Confirmed: visible native sun shadows disappeared when the native sun was overwritten with probe state and returned when the original native state was restored.
-- Confirmed: the same native `sun.shadow.map` object and the same two `additionalSunShadowMap` texture objects persisted through working -> broken -> restored states.
-- Unresolved: the hidden renderer/controller path that refreshes or validates visible sun shadows.
+- Corrected by v0.6: the two traced `additionalSunShadowMap` textures are static environment-shadow image assets (`summonCircle_shadow_512.webp` and `foliage_shadow_512.webp`), not the dynamic native sun shadow map or renderer-owned shadow targets.
+- Confirmed by v0.6: the static texture versions/backing images, native `sun.shadow.map`, native shadow matrix, material shadow states, detailed bindings, and traced resource identities remained unchanged across baseline -> native-sun override -> restore.
+- Observed: visible native sun shadows disappeared when the native sun was overwritten with probe state and returned when the original native state was restored.
+- Strong current inference: direct mutation changes the sun's visible illumination without regenerating the native shadow projection/map; restoring the original sun transform realigns the unchanged shadow data and makes the shadows visible again.
+- Unresolved: the actual update/render mechanism that regenerates the native sun shadow map/matrix after a legitimate HeroForge lighting change.
 - Unresolved: a third custom SphereLight is counted by materials but does not visibly illuminate, even when it is the only registered SphereLight.
-- Current priority: run/analyze v0.6 backing-resource diagnostics, checkpoint the result, then split the cumulative harness into a compact Lighting Injection Reference and focused Shadow Pipeline Probe.
+- Current priority: split the cumulative harness into a compact Lighting Injection Reference and focused Shadow Pipeline Probe, then make the shadow probe target the actual native `sun.shadow` refresh/update path rather than the static `additionalSunShadowMap` assets.
 - Eventual integration direction: a separate `/tools/` lighting module registering into the Booth tab, not experimental lighting logic merged into `tools/Booth.js`.
 - Persistent Booth remains separate and unchanged unless an isolated compatibility regression proves a concrete integration requirement.
 
@@ -256,8 +257,8 @@ This is the source bible for the current Witch Dock repository state. Keep this 
 - Backfill project history from previous chats.
 - Keep `HISTORY/STANDALONE_REFERENCES.md` current as standalone/probe sources are recovered or created.
 - Fill `HISTORY/BULLSHIT/` topic files with durable HeroForge engine discoveries.
-- Run and analyze `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`, then checkpoint the result before the next material lighting probe/code stage.
-- Split the cumulative lighting harness into a compact Lighting Injection Reference and focused Shadow Pipeline Probe after the v0.6 result is documented.
+- Split the cumulative lighting harness into a compact Lighting Injection Reference and focused Shadow Pipeline Probe now that the v0.6 result is documented.
+- Focus the next shadow probe on the actual native `sun.shadow` refresh/update mechanism and legitimate HeroForge lighting-state transitions, not the static `additionalSunShadowMap` environment assets.
 - After the physical-light foundation stabilizes, run a read-only shader-hook probe for camera-relative Fresnel/rim lighting.
 - Add deeper old-chat recovery notes for Booth minor fixes/effects edge cases, bones/kitbashing, JSON/library, and remaining standalone references.
 - Investigate Photo Mode PNG Series Capture using existing probe history and the dedicated feature spec before writing new implementation.
@@ -270,7 +271,7 @@ Add standalone scripts here when they are ready to migrate into Witch Dock. Deta
 | Tool / Script | Canonical Source | Target Location | Status | Notes |
 |---|---|---|---|---|
 | HF Core Tweaks / Lob decal slot reference | External user-provided / Lob-style Tampermonkey script | TBD; maybe direct HF Core Tweaks edit or `HeroForge_UI/` bridge strategy | External canonical reference | Compare before any slot-expansion edit. Current Witch Dock expansion depends on HF Core Tweaks signature and does not replace it. |
-| Advanced Lighting / Extra Lights | Lighting Probe v0.1.0; compact injection behavior in Injection Probe v0.3.0; diagnostics through v0.6.0 | Future separate `/tools/` lighting module, intended to register into the Booth tab | Investigating / unresolved | Second DirectionalLight works. Independent visible custom shadows are not confirmed. Run/analyze v0.6, then split the cumulative harness before migration. Do not merge experimental lighting logic into `tools/Booth.js`. |
+| Advanced Lighting / Extra Lights | Lighting Probe v0.1.0; compact injection behavior in Injection Probe v0.3.0; diagnostics through v0.6.0 | Future separate `/tools/` lighting module, intended to register into the Booth tab | Investigating / unresolved | Second DirectionalLight works. v0.6 ruled out the traced `additionalSunShadowMap` assets as the dynamic native shadow path. Split the cumulative harness, then target actual native `sun.shadow` refresh/update behavior. Do not merge experimental lighting logic into `tools/Booth.js`. |
 | Camera-Relative Rim Lighting | Future read-only shader-hook probe | TBD; separate shader/material subsystem | Queued / unproven | Fresnel rim queued after physical-light stabilization. Do not fold into physical-light injection. |
 | Decal Slot Swapper | New feature investigation / future probes | TBD, likely `/tools/` plus optional `/HeroForge_UI/` native Decals UI injection | Investigating / unresolved | Move/swap decal data between slots while preserving placement/transforms, color/material data, source/projection target, and undo/redo integration. |
 | Photo Mode PNG Series Capture | Prior standalone probes / old-chat history + `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md` | TBD, likely `/tools/` or clearly separated Booth subsection | Investigating / unresolved | First target should be 1024x1024, around 72 PNG frames, ZIP output, metadata, explicit arming, validated dimensions, and preserved Photo Booth effects. Persistent Booth is separate and already working. |
@@ -290,7 +291,8 @@ Add standalone scripts here when they are ready to migrate into Witch Dock. Deta
 - Booth, Decals, bone detection, JSON/library, and custom lighting workflows are high-fragility areas.
 - Persistent Booth is live/working. Do not classify it as an open PNG-series capture task or modify it for lighting without isolated evidence.
 - A second custom DirectionalLight visibly works, but reliable visible independent custom shadows are not confirmed.
-- HeroForge's visible sun-shadow path uses separate persistent `additionalSunShadowMap` texture objects whose hidden update/content lifecycle remains unresolved.
+- The two traced `additionalSunShadowMap` textures are static environment-shadow image assets, not the unresolved dynamic native sun-shadow path.
+- Direct native-sun mutation does not refresh the captured native shadow map/matrix state; visible shadow loss/recovery currently tracks whether the light transform matches the unchanged shadow data.
 - A third SphereLight being counted by materials does not mean it contributes visible illumination.
 - PNG series capture is not solved; avoid assumptions about 512x512 limits, DOM/CSS booth frame control, hidden HDR/16-bit buffer access, or large ZIP reliability.
 - High-resolution PNG sequences may stress browser memory/download behavior; start at 1024 before scaling to 2048/4K.
@@ -308,3 +310,4 @@ Document removed, deprecated, or rejected work here with the reason.
 | Treating material light counts as proof of visible illumination | Rejected | The third SphereLight increments `numSphereLights` but does not visibly illuminate even when it is the only registered SphereLight. | 2026-07-12 |
 | Treating `numDirLightShadows` as the sole Photo Booth shadow-success signal | Rejected | The counter does not fully describe HeroForge's sun-specific/custom shadow paths, but an allocated map also does not prove visible custom shadowing. Use multiple diagnostics plus direct visual reproduction. | 2026-07-13 |
 | Treating an allocated custom shadow map as proof of visible independent custom DirectionalLight shadows | Rejected | Later controlled v0.4-v0.5 runs did not reproduce the initial v0.3 visual result; character materials may not consume the generic custom shadow resource. | 2026-07-13 |
+| Treating `additionalSunShadowMap` as the dynamic native sun-shadow path | Rejected | Probe v0.6 identified the traced resources as ordinary static 512x512 environment-shadow image textures for the summon circle and foliage. | 2026-07-14 |

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -2,6 +2,57 @@
 
 Use this file before repo updates to record what was checked, what could conflict, and what action is recommended.
 
+## PFC-2026-07-14-010 — Advanced Lighting Probe v0.6 Result Checkpoint
+
+Date: 2026-07-14
+Time: 16:40 PDT
+
+Target files:
+- `MASTER.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+Relevant history checked:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/SESSION_LOG.md`
+- prior Lighting Injection Probe v0.4.0 and v0.5.0 findings
+- `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`
+- `HF_Lighting_Injection_Probe_v0.6.0_2026-07-14T23-37-19-231Z.json`
+- user-observed prior behavior that visible native sun shadows disappeared after native-sun override and returned after restore
+- project rules requiring documentation checkpoints before the next material probe/code stage
+
+Connected modules reviewed:
+- current standalone second-DirectionalLight reference status through `MASTER.md` and `HISTORY/STANDALONE_REFERENCES.md`
+- Persistent Booth separation through `MASTER.md` and existing lighting documentation
+- `manifest.json` loading rules through `MASTER.md`; no manifest change required
+- current shadow-probe scope and planned split into Lighting Injection Reference plus focused Shadow Pipeline Probe
+
+Conflict risks:
+- Documentation-only update.
+- No JavaScript files changed.
+- No standalone userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- The `additionalSunShadowMap` name is misleading for this investigation: v0.6 identified the traced resources as static summon-circle/foliage shadow image assets, so older active wording must not continue implying that those textures are the dynamic native sun-shadow pipeline.
+- The explanation that unchanged shadow data becomes spatially invalid when the sun moves and valid again when restored is a strong inference, not yet a directly proven renderer call path.
+- Persistent Booth remains live/working and separate; no edit to `tools/Booth.js` is justified.
+- `Knight-Witch/HeroForge.Compatibility` remains out of scope.
+
+Recommended action:
+- Proceed with a documentation-only checkpoint.
+- Mark Injection Probe v0.6.0 as a completed diagnostic milestone rather than an unvalidated active probe.
+- Correct the `additionalSunShadowMap` interpretation in project tracking and standalone-reference docs.
+- Record that the next focused shadow investigation must target the actual native `sun.shadow` refresh/update lifecycle and legitimate HeroForge lighting-state transitions.
+- Split the cumulative lighting harness before the next material code/probe branch.
+
 ## PFC-2026-07-13-009 — Advanced Lighting v0.4-v0.6 Documentation Correction and Sub-Project Checkpoint
 
 Date: 2026-07-13

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -10,6 +10,7 @@ Time: 16:40 PDT
 Target files:
 - `MASTER.md`
 - `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
 - `HISTORY/STANDALONE_REFERENCES.md`
 - `HISTORY/SESSION_LOG.md`
 - `PRE_FLIGHT_Check.md`
@@ -49,7 +50,7 @@ Conflict risks:
 Recommended action:
 - Proceed with a documentation-only checkpoint.
 - Mark Injection Probe v0.6.0 as a completed diagnostic milestone rather than an unvalidated active probe.
-- Correct the `additionalSunShadowMap` interpretation in project tracking and standalone-reference docs.
+- Correct the `additionalSunShadowMap` interpretation in the canonical Advanced Lighting spec, project tracking, and standalone-reference docs.
 - Record that the next focused shadow investigation must target the actual native `sun.shadow` refresh/update lifecycle and legitimate HeroForge lighting-state transitions.
 - Split the cumulative lighting harness before the next material code/probe branch.
 


### PR DESCRIPTION
Documentation-only checkpoint for the validated Advanced Lighting Probe v0.6 result.

- Corrects the `additionalSunShadowMap` interpretation: the two traced resources are static summon-circle and foliage shadow image assets, not the dynamic native sun-shadow path.
- Records that the native `sun.shadow.map`, shadow matrix, material shadow state, bindings, and traced resource structures remained unchanged while the native sun was overridden and restored.
- Records the current stale/unrefreshed native-shadow-data inference without promoting it to a confirmed renderer call path.
- Marks v0.6 as a completed diagnostic correction milestone.
- Updates the Advanced Lighting spec, master tracker, Bullshit Bible, standalone reference inventory, session log, pre-flight log, and changelog.
- Sets the next investigation target to the actual native `sun.shadow` refresh/update lifecycle after the planned cumulative-probe split.

Documentation only. No JavaScript, standalone probe source, manifest, storage, UI, Persistent Booth, or runtime behavior changed.