### PR TITLE
Document native shadow refresh timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## DOCS-2026-07-14-011 — Native Shadow Refresh Comparison
+
+Date: 2026-07-14
+Time: 18:08 PDT
+
+### Added
+
+- Added `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md` as a focused technical appendix for the isolated native sun, environmental-lighting preset, and full Booth-preset shadow-refresh comparison.
+
+### Changed
+
+- Updated `HISTORY/Bullshit_Bible.md` with the confirmed two-stage native sun -> shadow-camera/matrix refresh behavior and the separate environmental-lighting result.
+- Updated `HISTORY/SESSION_LOG.md` with the three controlled Shadow Pipeline Probe v0.1.0 reports, timing findings, corrected shadow-pipeline model, and next probe target.
+- Updated `PRE_FLIGHT_Check.md` with target files, history checked, connected systems reviewed, conflict risks, and recommended next action.
+
+### Confirmed / Corrected Documentation
+
+- Confirmed that a legitimate native HeroForge sun adjustment changes the native sun position before the native shadow camera and `sun.shadow.matrix` update.
+- In the `906Z` sun-only run, the first post-interaction snapshot contained the new sun position with the old shadow camera/matrix; roughly 83 ms later the shadow camera position/rotation and shadow matrix were synchronized.
+- Confirmed that the successful native sun adjustment reused the existing shadow render-target and texture objects.
+- Confirmed that the tested environmental-lighting preset produced no captured change in native sun position/target/intensity/color, native shadow camera, native shadow matrix, or native shadow render-target/texture identity across 33 snapshots.
+- Narrowed the environmental-lighting conclusion: the probe did not deeply inspect `EnvironmentLight`, ambient-light, environment-map, or other environment-preset internals.
+- Confirmed that the full Booth preset changed native sun position, intensity, and color and ended with synchronized shadow camera/matrix state while retaining the existing shadow render-target objects.
+- Recorded the Booth-preset timing limitation: the first scheduled post-click snapshots were delayed until the composite preset had already resolved, so internal update ordering was not isolated.
+- Corrected the current shadow-pipeline model: the failed direct-property mutation is missing a concrete follow-up shadow-camera/matrix refresh phase, not an observed shadow render-target replacement.
+- Recorded that the next probe should enumerate and minimally instrument native `sun.shadow` instance methods during a clean native sun adjustment rather than guessing a method name.
+
+### Runtime Evidence
+
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-02-14-906Z.json` — native sun adjustment only.
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-03-42-554Z.json` — environmental lighting preset adjustment only.
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-04-50-087Z.json` — full Booth preset selection only.
+- All three reports contained zero recorded probe errors.
+
+### Touched Files
+
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+### Rollback Notes
+
+- Documentation-only checkpoint.
+- No JavaScript files changed.
+- No standalone userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- Rolling back would discard the durable record of the first isolated legitimate native shadow-camera/matrix refresh sequence.
+
+### Test Notes
+
+- Runtime evidence came from standalone Shadow Pipeline Probe v0.1.0 only.
+- No Witch Dock or Persistent Booth runtime code was changed or tested as part of this documentation checkpoint.
+
 ## DOCS-2026-07-14-010 — Advanced Lighting Probe v0.6 Static Shadow Texture Correction
 
 Date: 2026-07-14

--- a/HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md
+++ b/HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md
@@ -1,0 +1,210 @@
+# Lighting Shadow Refresh Diagnostics
+
+Focused diagnostic appendix for the Advanced Lighting / Extra Lights sub-project.
+
+Canonical project/spec file:
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+
+This file records the controlled native-shadow refresh comparison performed with `HeroForge_Shadow_Pipeline_Probe_v0.1.0.txt` after the cumulative lighting probe was split.
+
+## Status
+
+Confirmed diagnostic milestone.
+
+The comparison isolates three distinct HeroForge-controlled lighting transitions:
+
+1. native sun adjustment only;
+2. environmental lighting preset adjustment only;
+3. full Booth preset selection only.
+
+Reports:
+
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-02-14-906Z.json` — native sun adjustment only;
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-03-42-554Z.json` — environmental lighting preset adjustment only;
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-04-50-087Z.json` — full Booth preset selection only.
+
+All three reports recorded zero probe errors.
+
+## Critical Finding
+
+A legitimate native sun adjustment uses a two-stage update sequence that the earlier direct-property mutation did not reproduce.
+
+Observed sequence in the `906Z` sun-only report:
+
+1. Baseline native sun position:
+   - `x = 8.826620169431965`
+   - `y = 9.805237071293732`
+   - `z = 1.796563371090197`
+2. User adjusts the native sun through HeroForge UI.
+3. First post-interaction snapshot:
+   - sun position has already changed to:
+     - `x = 4.796861604800018`
+     - `y = 9.805237071293728`
+     - `z = -7.624105344639563`
+   - native shadow camera is still at the old baseline position;
+   - native `sun.shadow.matrix` is still the old baseline matrix.
+4. Approximately 83 ms later in the captured run:
+   - native shadow camera position updates to the new sun position;
+   - native shadow camera rotation updates;
+   - native `sun.shadow.matrix` updates.
+5. The existing native shadow render target and texture objects remain the same objects.
+
+This is the first direct proof in this investigation that HeroForge performs a follow-up shadow-camera/matrix refresh after a legitimate native sun control change.
+
+## Native Sun Adjustment — `906Z`
+
+### Confirmed
+
+- Native sun position changed immediately before the captured native shadow camera/matrix update.
+- The first `0ms` post-interaction snapshots showed the new sun position with the old shadow camera and old shadow matrix.
+- The scheduled `50ms` snapshot executed roughly 83 ms after the first post-interaction snapshot and showed:
+  - updated shadow camera position;
+  - updated shadow camera rotation;
+  - updated native shadow matrix.
+- The native shadow render-target UUID remained stable.
+- The native shadow-map texture UUID remained stable.
+- The shadow-map texture version remained `0` in the captured JavaScript state.
+
+### Meaning
+
+A successful native sun move does not require replacement of the shadow render target or its texture object.
+
+The important observable transition is:
+
+`sun position change -> delayed shadow camera/matrix synchronization`
+
+The earlier direct-mutation probe changed the sun position/intensity/color but never produced this second synchronization phase.
+
+## Environmental Lighting Preset — `554Z`
+
+### Confirmed
+
+Across 33 captured snapshots:
+
+- no `native-shadow-state-change-detected` action fired;
+- native sun position remained unchanged;
+- native sun target remained unchanged;
+- native sun intensity remained unchanged;
+- native sun color remained unchanged;
+- native shadow camera state remained unchanged;
+- native `sun.shadow.matrix` remained unchanged;
+- native shadow render-target and texture identities remained unchanged.
+
+A full recursive comparison of the probe's captured baseline and final native-shadow snapshots found no captured state difference other than timestamp/reason metadata.
+
+### Narrow interpretation
+
+This proves only that the tested environmental-lighting preset did not change the native sun or native `sun.shadow` state captured by this probe.
+
+It does not prove that environmental lighting itself did nothing.
+
+The current Shadow Pipeline Probe does not deeply snapshot the internal state of `EnvironmentLight`, ambient lighting, environment maps, or all environment-preset resources.
+
+Current rule:
+
+- treat environmental-lighting presets as a separate lighting subsystem unless later evidence shows they intentionally drive native directional shadows;
+- do not use the `554Z` result to claim that environment presets cannot affect any kind of shading, occlusion, reflections, ambient contribution, or environment lighting.
+
+## Full Booth Preset — `087Z`
+
+### Confirmed
+
+The Booth preset changed the native sun from:
+
+- position approximately `(8.8266, 9.9011, 1.7966)`
+- intensity `0.85`
+- color `#ffffff`
+
+to:
+
+- position approximately `(8.0590, 9.8106, 4.2038)`
+- intensity `0.31`
+- color `#e5bb94`
+
+The first captured post-preset state also contained:
+
+- updated native shadow camera position;
+- updated native shadow camera rotation;
+- updated native `sun.shadow.matrix`.
+
+The existing shadow render-target and texture objects remained in place.
+
+### Timing limitation
+
+The Booth preset is a composite operation.
+
+The click was recorded at approximately `01:04:28.512Z`, while the first scheduled post-interaction snapshots did not execute until approximately `01:04:34.416Z`.
+
+By that time the sun and shadow camera/matrix were already synchronized.
+
+Therefore this report does not reveal the internal ordering of the Booth preset transition.
+
+It proves that the completed Booth-preset path ends with synchronized native sun and shadow state, but not whether the preset uses the exact same immediate/delayed sequence as the manual sun adjustment.
+
+## Corrected Shadow-Pipeline Model
+
+The earlier v0.6 model correctly identified that direct native-sun mutation failed to refresh the native shadow state, but the mechanism is now more specific.
+
+### Failed direct mutation
+
+`direct sun property mutation`
+
+-> visible illumination changes
+
+-> native shadow camera remains stale
+
+-> native `sun.shadow.matrix` remains stale
+
+-> visible shadow result becomes invalid or disappears
+
+### Legitimate native sun control
+
+`HeroForge native sun control`
+
+-> sun transform changes
+
+-> short delayed refresh phase
+
+-> native shadow camera position/rotation synchronize to the new sun state
+
+-> native `sun.shadow.matrix` recalculates
+
+-> existing shadow render target continues to be used
+
+This narrows the missing behavior from a vague hidden resource replacement to a concrete shadow-camera/matrix update lifecycle.
+
+## Next Probe Target
+
+Do not guess the refresh method yet.
+
+The next Shadow Pipeline Probe should observe the callable API around the actual native shadow object during a legitimate native sun adjustment.
+
+Recommended scope:
+
+1. Enumerate callable own/prototype methods on:
+   - native `sun.shadow`;
+   - native shadow camera;
+   - native sun object.
+2. Instrument only the smallest relevant native shadow instance methods, not broad global prototypes.
+3. Preserve original functions exactly and restore them automatically after the watch ends.
+4. Capture:
+   - method name;
+   - timestamp;
+   - argument summaries;
+   - before/after sun position;
+   - before/after shadow camera state;
+   - before/after shadow-matrix hash;
+   - short stack trace where available.
+5. Repeat the clean native sun-adjustment test.
+6. Identify the method or call chain that occurs during the approximately 80 ms refresh phase.
+
+A likely Three.js-family concept is a shadow-matrix update routine, but no exact method name should be treated as confirmed until runtime observation proves it.
+
+## Do Not Repeat
+
+- Do not continue searching for a replacement shadow render target when legitimate sun adjustment reuses the existing object.
+- Do not assume texture `version` must change when a render target is rerendered.
+- Do not infer environment-preset internals from the native sun/shadow snapshot alone.
+- Do not use the full Booth preset as the primary timing reference when the manual sun control provides a cleaner isolated two-stage transition.
+- Do not globally monkey-patch renderer or light prototypes before the native shadow instance API is enumerated.
+- Do not modify Persistent Booth for this investigation.

--- a/HISTORY/Bullshit_Bible.md
+++ b/HISTORY/Bullshit_Bible.md
@@ -50,6 +50,7 @@ Current status:
 
 Detailed notes live in:
 - `BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
 - `BULLSHIT/TIMING_AND_STATE.md`
 - `BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
 - `../STANDALONE_REFERENCES.md`
@@ -58,9 +59,11 @@ Current status:
 - A second custom DirectionalLight is confirmed working for visible illumination, position, and intensity.
 - Independent visible custom DirectionalLight shadows are not confirmed; later controlled runs did not reproduce the initial v0.3 visual result.
 - Probe v0.6.0 confirmed the two previously traced `additionalSunShadowMap` textures are ordinary static image textures for `summonCircle_shadow_512.webp` and `foliage_shadow_512.webp`, not dynamic native sun shadow render targets.
-- The native `sun.shadow.map`, native shadow matrix, material shadow bindings, traced resource identities, and those static texture diagnostics remained unchanged while the native sun was overridden and then restored.
-- Native visible sun shadows disappeared when the native sun was overwritten with probe state and returned when the original native sun state was restored.
-- Strong current inference: direct light mutation changes illumination without regenerating the native shadow projection/map; restoring the original sun transform realigns the unchanged native shadow data.
+- Shadow Pipeline Probe v0.1.0 isolated the legitimate native sun refresh sequence: the native sun position changes first, then the native shadow camera and `sun.shadow.matrix` update in a short delayed second phase.
+- In the isolated sun-adjustment run, the first post-interaction snapshot had the new sun position but the old shadow camera/matrix; roughly 83 ms later the camera and matrix were synchronized.
+- The successful native update reused the existing shadow render-target and texture objects.
+- The tested environmental-lighting preset did not alter any captured native sun or native `sun.shadow` state; this does not describe unobserved `EnvironmentLight` internals.
+- A full Booth preset ended with synchronized sun and native shadow state but its composite transition timing was not isolated.
 - A third custom SphereLight is counted by materials but does not visibly illuminate.
 - Camera-relative Fresnel/rim lighting is queued after the physical-light foundation stabilizes.
 - This is standalone sub-project work, not a live Witch Dock module.
@@ -71,6 +74,8 @@ Current rules:
 - Do not treat an allocated shadow map as proof that character materials visibly consume it.
 - Do not treat `additionalSunShadowMap` as the native dynamic sun-shadow path merely because of its name; inspect the actual resource type and asset source.
 - Do not claim reliable visible custom DirectionalLight shadows from the initial v0.3 observation.
+- Preserve the observed two-stage native sun -> shadow-camera/matrix refresh timing until the actual method call path is identified.
+- Do not assume a successful native sun move replaces the shadow render target; the isolated native control reused the existing object.
 - Do not blame or modify Persistent Booth without an isolated compatibility regression.
 - Keep physical DirectionalLight/SphereLight injection separate from future shader-based rim lighting.
 - Keep Advanced Lighting runtime logic separate from `tools/Booth.js` even if the eventual UI lives under the Booth tab.
@@ -93,6 +98,7 @@ Current rule:
 - `BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
 - `BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
 - `BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
 - `BULLSHIT/KITBASHING_AND_BONES.md`
 - `BULLSHIT/JSON_AND_LIBRARY.md`
 - `BULLSHIT/MANIFEST_AND_LOADING.md`

--- a/HISTORY/SESSION_LOG.md
+++ b/HISTORY/SESSION_LOG.md
@@ -2,6 +2,18 @@
 
 Chronological development and testing notes. Use this for concise project-state updates that matter across chats.
 
+## 2026-07-14 — Native Shadow Refresh Comparison
+
+- Target: compare three legitimate HeroForge lighting transitions after splitting the cumulative lighting harness: native sun adjustment only, environmental lighting preset only, and full Booth preset only.
+- Action: analyzed `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-02-14-906Z.json`, `...01-03-42-554Z.json`, and `...01-04-50-087Z.json`.
+- Result — native sun adjustment: the first post-interaction snapshot showed the new sun position while the native shadow camera and `sun.shadow.matrix` were still at baseline; roughly 83 ms later the shadow camera position/rotation and shadow matrix updated to the new sun state. The existing shadow render target and texture objects remained in place.
+- Result — environmental lighting preset: across 33 snapshots, no captured native sun or native `sun.shadow` field changed and no native-shadow change event fired. This is intentionally narrow; the probe did not deeply capture `EnvironmentLight` internals.
+- Result — full Booth preset: the completed preset changed native sun position, intensity, and color and ended with updated shadow camera/matrix state while reusing the existing shadow render-target objects. The first scheduled post-click callbacks were delayed until the composite preset had already resolved, so internal ordering was not isolated.
+- Correction: the missing behavior in the failed direct-mutation path is now concretely narrowed to the follow-up shadow-camera/matrix refresh phase rather than an unidentified shadow render-target replacement.
+- Documentation: added `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md` as a focused technical appendix.
+- Test notes: standalone probe runtime only; no Witch Dock JavaScript, `manifest.json`, Persistent Booth, storage, or live runtime behavior changed.
+- Follow-up: enumerate and minimally instrument callable methods on the native `sun.shadow` instance during another clean native sun adjustment to identify the exact method/call chain that performs the delayed refresh.
+
 ## 2026-07-14 — Advanced Lighting Probe v0.6 Result
 
 - Target: determine whether the two persistent `additionalSunShadowMap` textures changed internally across working baseline -> broken native-sun override -> restored native state.

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -2,6 +2,64 @@
 
 Use this file before repo updates to record what was checked, what could conflict, and what action is recommended.
 
+## PFC-2026-07-14-011 — Native Shadow Refresh Comparison Checkpoint
+
+Date: 2026-07-14
+Time: 18:08 PDT
+
+Target files:
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+Relevant history checked:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/SESSION_LOG.md`
+- completed Lighting Injection Probe v0.6 findings
+- `HeroForge_Shadow_Pipeline_Probe_v0.1.0.txt`
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-02-14-906Z.json` — native sun adjustment only
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-03-42-554Z.json` — environmental lighting preset adjustment only
+- `HF_Shadow_Pipeline_Probe_v0.1.0_2026-07-15T01-04-50-087Z.json` — full Booth preset selection only
+- user clarification that environmental lighting presets are distinct from full Booth presets
+- project rules requiring a documentation checkpoint before the next material shadow-probe code stage
+
+Connected modules reviewed:
+- current standalone second-DirectionalLight and shadow-probe separation through existing lighting documentation
+- native sun, shadow camera, shadow matrix, render-target, and interaction timing fields captured by Shadow Pipeline Probe v0.1.0
+- Persistent Booth separation through `MASTER.md` and existing Booth/lighting documentation
+- `manifest.json` loading rules through `MASTER.md`; no manifest change required
+
+Conflict risks:
+- Documentation-only update.
+- No JavaScript files changed.
+- No standalone userscript probe files changed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- The environmental-lighting result is narrow: the tested preset did not alter the captured native sun or native `sun.shadow` state, but the current probe did not deeply inspect `EnvironmentLight`, ambient-light, or environment-map internals.
+- The full Booth preset is a composite operation; its first scheduled post-click snapshots were delayed until the preset had already resolved, so its internal sun-vs-shadow update ordering was not isolated.
+- The isolated native sun-adjustment report is the clean timing reference: sun position changed before the native shadow camera and shadow matrix, which synchronized roughly 83 ms later in the captured run.
+- Stable render-target/texture object identity does not prove GPU contents are unchanged; successful native sun adjustment can rerender into the existing target.
+- Exact refresh method name remains unproven. Do not assume a Three.js-family method such as `updateMatrices` is the HeroForge call path until runtime tracing confirms it.
+- Persistent Booth remains live/working and separate; no edit to `tools/Booth.js` is justified.
+- `Knight-Witch/HeroForge.Compatibility` remains out of scope.
+
+Recommended action:
+- Proceed with a documentation-only checkpoint before the next material probe code stage.
+- Add a focused native-shadow refresh diagnostic appendix rather than another overlapping Advanced Lighting project-plan document.
+- Record the confirmed two-stage native sun -> shadow-camera/matrix refresh sequence.
+- Record the environmental-lighting preset as separate from captured native directional-shadow state.
+- Record the full Booth preset result with its timing limitation.
+- Next probe should enumerate and minimally instrument callable methods on the native `sun.shadow` instance during a clean native sun adjustment, restoring all wrappers after the watch ends.
+
 ## PFC-2026-07-14-010 — Advanced Lighting Probe v0.6 Result Checkpoint
 
 Date: 2026-07-14


### PR DESCRIPTION
Documentation-only checkpoint for Shadow Pipeline Probe v0.1.0.

- Records the isolated native sun adjustment sequence where sun position changes first and the native shadow camera/matrix synchronize roughly 83 ms later.
- Records that the successful native update reuses the existing shadow render-target and texture objects.
- Records that the tested environmental-lighting preset did not alter captured native sun or native sun-shadow state, while explicitly preserving the limitation that EnvironmentLight internals were not deeply inspected.
- Records that a full Booth preset ends with synchronized sun and shadow state but does not expose internal ordering because the first scheduled post-click snapshots were delayed until the composite preset resolved.
- Adds a focused shadow-refresh diagnostic appendix and updates the Bullshit Bible, session log, pre-flight log, and changelog.

Documentation only. No JavaScript, standalone probe source, manifest, storage, UI, Persistent Booth, or runtime behavior changed.