### PR TITLE
Document Shadow Pipeline Probe v0.2 findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## DOCS-2026-07-15-012 — Shadow Pipeline Probe v0.2 Negative Result and v0.3 Target
+
+Date: 2026-07-15
+Time: 00:58 PDT
+
+### Changed
+
+- Updated `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md` with the Shadow Pipeline Probe v0.2.0 result, wrapper-selection correction, scene-graph dirty-state evidence, and the v0.3 targeted live-instance trace plan.
+- Updated `HISTORY/SESSION_LOG.md` with the v0.2 runtime result and current v0.3 artifact/test status.
+- Updated `PRE_FLIGHT_Check.md` with the required target files, history reviewed, connected systems, conflict risks, and recommended action.
+
+### Confirmed / Corrected Documentation
+
+- Confirmed that native `sun.shadow` exposes no obvious callable refresh/update method in its observed prototype chain; beyond plain `Object` methods, the inventory found only `clone`, `copy`, and `toJSON`.
+- Corrected the v0.2 zero-call interpretation: the trace excluded `clone`, `copy`, and `toJSON`, accidentally wrapped inherited `toLocaleString`, and therefore recorded zero calls to an irrelevant method. This does not prove that the refresh path is method-free.
+- Recorded one v0.2 transition where the native sun and lighting root were matrix-dirty while the shadow camera/matrix were stale, followed by a later synchronized camera/matrix state with those dirty flags cleared.
+- Recorded the timing limitation that the v0.2 run contained multiple watched UI interactions, so the elapsed time between those dirty and synchronized states is not treated as an isolated automatic refresh delay.
+- Narrowed the next target to specific live sun, sun-position, sun-target-position, shadow-camera, shadow-camera-position, and shadow-matrix instances rather than `sun.shadow` itself.
+- Recorded `HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` as a newly created local standalone test artifact that passed syntax and stub-initialization checks but has not yet been runtime-validated in HeroForge.
+
+### Runtime Evidence
+
+- `HF_Shadow_Pipeline_Probe_v0.2.0_2026-07-15T07-40-40-928Z.json`.
+- Probe report contained zero recorded errors.
+- Probe installed one wrapper: inherited `toLocaleString`.
+- Recorded method-call count: `0`.
+
+### Touched Files
+
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+### Rollback Notes
+
+- Documentation-only checkpoint.
+- No Witch Dock JavaScript files changed.
+- No standalone userscript probe source was committed by this update.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- Rolling back would remove the durable record that v0.2 targeted the wrong object and could cause a future session to repeat direct `sun.shadow` method tracing.
+
+### Test Notes
+
+- Runtime evidence came from standalone Shadow Pipeline Probe v0.2.0 only.
+- `HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` was syntax-checked with `node --check` using a temporary `.js` copy and initialized successfully in a stub userscript runtime.
+- No Witch Dock or Persistent Booth runtime code was changed or tested as part of this documentation checkpoint.
+
 ## DOCS-2026-07-14-011 — Native Shadow Refresh Comparison
 
 Date: 2026-07-14

--- a/HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md
+++ b/HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md
@@ -173,32 +173,99 @@ The earlier v0.6 model correctly identified that direct native-sun mutation fail
 
 This narrows the missing behavior from a vague hidden resource replacement to a concrete shadow-camera/matrix update lifecycle.
 
+## Shadow Pipeline Probe v0.2.0 — Native `sun.shadow` Method Trace
+
+Report:
+
+- `HF_Shadow_Pipeline_Probe_v0.2.0_2026-07-15T07-40-40-928Z.json`
+
+### Confirmed negative result
+
+The native `sun.shadow` object does not expose an obvious refresh/update method on its callable prototype chain.
+
+The only non-`Object` callable methods found were:
+
+- `clone`
+- `copy`
+- `toJSON`
+
+The v0.2 trace excluded those serialization/copy methods. Because `toLocaleString` was not included in the exclusion list, the wrapper-selection logic accidentally installed a wrapper only for inherited `Object.prototype.toLocaleString`.
+
+Result:
+
+- wrapper count: `1`;
+- wrapped method: `toLocaleString`;
+- recorded method calls: `0`;
+- probe errors: `0`.
+
+This does **not** prove that the shadow refresh occurs without method calls.
+
+It proves that the v0.2 target was wrong: the useful refresh behavior is not exposed as a callable method on the native `sun.shadow` object itself.
+
+### Additional dirty-state evidence
+
+One captured transition showed:
+
+- native sun position changed to `(9, 10, 2)`;
+- native sun target changed to `(0, 2, 0)`;
+- native shadow camera and shadow matrix were still at the previous state;
+- `sun._matrixNeedsUpdate = 1`;
+- `sun._matrixWorldNeedsUpdate = 1`;
+- `lightingRoot._matrixWorldNeedsUpdate = 1`.
+
+A later captured state showed:
+
+- shadow camera synchronized to `(9, 10, 2)`;
+- shadow camera rotation updated;
+- `sun.shadow.matrix` changed;
+- the above matrix-dirty flags returned to `0`.
+
+The v0.2 run contained multiple watched UI interactions, so the elapsed time between those two snapshots must not be treated as an isolated automatic refresh delay.
+
+However, the state transition supports a stronger current model:
+
+`native sun mutation -> scene-graph matrix dirty state -> external camera/matrix refresh path -> dirty flags clear`
+
+### Current interpretation
+
+The shadow refresh is likely performed externally by a renderer, scene-graph update routine, or lighting controller that directly mutates:
+
+- native sun transform/update state;
+- native shadow camera transform/state;
+- native shadow matrix.
+
+This is consistent with the native `sun.shadow` prototype exposing no useful update method.
+
+Do not claim an exact renderer method or call chain yet.
+
 ## Next Probe Target
 
-Do not guess the refresh method yet.
+`HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` should trace only the specific live instances involved in the confirmed refresh sequence.
 
-The next Shadow Pipeline Probe should observe the callable API around the actual native shadow object during a legitimate native sun adjustment.
+Target instances:
 
-Recommended scope:
+1. native sun object;
+2. native sun position vector;
+3. native sun target-position vector;
+4. native shadow camera object;
+5. native shadow-camera position vector;
+6. native shadow matrix object.
 
-1. Enumerate callable own/prototype methods on:
-   - native `sun.shadow`;
-   - native shadow camera;
-   - native sun object.
-2. Instrument only the smallest relevant native shadow instance methods, not broad global prototypes.
-3. Preserve original functions exactly and restore them automatically after the watch ends.
-4. Capture:
-   - method name;
-   - timestamp;
-   - argument summaries;
-   - before/after sun position;
-   - before/after shadow camera state;
-   - before/after shadow-matrix hash;
-   - short stack trace where available.
-5. Repeat the clean native sun-adjustment test.
-6. Identify the method or call chain that occurs during the approximately 80 ms refresh phase.
+Target method families:
 
-A likely Three.js-family concept is a shadow-matrix update routine, but no exact method name should be treated as confirmed until runtime observation proves it.
+- matrix/world-matrix dirty/update methods on the native sun and shadow camera;
+- vector mutators such as `set` and `copy` on sun/camera position objects;
+- camera `lookAt`/transform update methods;
+- shadow-matrix mutators such as `set`, `copy`, `multiply`, `multiplyMatrices`, and related matrix composition methods.
+
+Rules:
+
+- wrap only those specific live instances;
+- do not patch global light, camera, vector, matrix, or renderer prototypes;
+- preserve original `this`, arguments, return values, exceptions, descriptors, and automatic restoration;
+- capture short call stacks and compact before/after dirty-state snapshots;
+- have the native Sun controls already open before arming the trace to reduce unrelated UI interactions;
+- test one native sun adjustment only.
 
 ## Do Not Repeat
 
@@ -206,5 +273,7 @@ A likely Three.js-family concept is a shadow-matrix update routine, but no exact
 - Do not assume texture `version` must change when a render target is rerendered.
 - Do not infer environment-preset internals from the native sun/shadow snapshot alone.
 - Do not use the full Booth preset as the primary timing reference when the manual sun control provides a cleaner isolated two-stage transition.
-- Do not globally monkey-patch renderer or light prototypes before the native shadow instance API is enumerated.
+- Do not interpret the v0.2 zero-call result as proof that no method-based update occurs; only an irrelevant inherited `toLocaleString` method was actually wrapped.
+- Do not keep targeting `sun.shadow` itself for an update method unless new runtime evidence exposes one.
+- Do not globally monkey-patch renderer or light prototypes before the targeted live-instance trace is exhausted.
 - Do not modify Persistent Booth for this investigation.

--- a/HISTORY/SESSION_LOG.md
+++ b/HISTORY/SESSION_LOG.md
@@ -2,6 +2,18 @@
 
 Chronological development and testing notes. Use this for concise project-state updates that matter across chats.
 
+## 2026-07-15 — Shadow Pipeline Probe v0.2 Result and v0.3 Trace Target
+
+- Target: identify the callable native `sun.shadow` method responsible for the legitimate shadow-camera/matrix refresh observed in the v0.1 sun-only comparison.
+- Action: analyzed `HF_Shadow_Pipeline_Probe_v0.2.0_2026-07-15T07-40-40-928Z.json` and reviewed the exact v0.2 wrapper-selection implementation.
+- Result: native `sun.shadow` exposed only `clone`, `copy`, and `toJSON` beyond plain `Object` methods. Those three were intentionally excluded from tracing, while inherited `toLocaleString` was accidentally not excluded. The probe therefore wrapped only `toLocaleString` and recorded zero method calls.
+- Correction: the zero-call result does not prove that shadow refresh occurs without method calls. It proves that `sun.shadow` itself does not expose an obvious useful refresh method and that the v0.2 trace targeted the wrong object.
+- Additional finding: one captured transition showed the native sun and lighting root marked matrix-dirty while the shadow camera/matrix were still stale; a later captured state showed the shadow camera/matrix synchronized and those dirty flags cleared. Because the run contained multiple watched UI interactions, the elapsed time between those states is not treated as a clean automatic delay measurement.
+- Current direction: trace only the specific live sun, sun-position, sun-target-position, shadow-camera, shadow-camera-position, and shadow-matrix instances. Capture targeted mutator/update calls, stacks, and compact before/after dirty state. Do not patch global prototypes.
+- Artifact status: `HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` and its diff were created locally from v0.2.0 and syntax/stub-initialization checked; live HeroForge runtime validation is still pending.
+- Test notes: standalone diagnostic work only; no Witch Dock JavaScript, `manifest.json`, Persistent Booth, storage, UI, or live runtime behavior changed.
+- Follow-up: run v0.3.0 with the native Sun controls already open, arm the refresh trace, perform one native sun adjustment only, then analyze the report.
+
 ## 2026-07-14 — Native Shadow Refresh Comparison
 
 - Target: compare three legitimate HeroForge lighting transitions after splitting the cumulative lighting harness: native sun adjustment only, environmental lighting preset only, and full Booth preset only.
@@ -29,7 +41,7 @@ Chronological development and testing notes. Use this for concise project-state 
 
 - Target: correct the stale Advanced Lighting documentation after probe work continued beyond the July 12 v0.3 checkpoint.
 - Action: renamed the dedicated sub-project/spec from `LIGHTING_AND_SHADOWS.md` to `LIGHTING_AND_EXTRA_LIGHTS.md`; documented Injection Probe v0.4.0 and v0.5.0 results; registered v0.6.0 as the current active unvalidated diagnostic probe; corrected the earlier custom-shadow claim; recorded the planned split into a compact Lighting Injection Reference and focused Shadow Pipeline Probe.
-- Result: repo memory now records that visible independent custom DirectionalLight shadows are not confirmed, that HeroForge uses separate persistent `additionalSunShadowMap` textures on `HF.summonCircle` materials, that native visible shadows disappear when native sun state is overwritten and return when the original state is restored, and that the same shadow-resource object identities persist across working -> broken -> restored states.
+- Result: repo memory now records that visible independent custom DirectionalLight shadows are not confirmed, that HeroForge uses separate persistent `additionalSunShadowMap` textures on `HF.summonCircle` materials, that native visible shadows disappear when native sun state is overwritten and return when the original native sun state is restored, and that the same shadow-resource object identities persist across working -> broken -> restored states.
 - Architecture: Advanced Lighting remains a standalone sub-project intended for a separate future module under the Witch Dock Booth tab; `tools/Booth.js` and Persistent Booth remain separate and unchanged.
 - Test notes: documentation-only update; no JavaScript, userscript probe source, `manifest.json`, storage keys, UI, or runtime behavior changed.
 - Follow-up: run and analyze `HeroForge_Lighting_Injection_Probe_v0.6.0.txt`, checkpoint the result, then split the cumulative harness before the next major diagnostic branch.

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -2,6 +2,59 @@
 
 Use this file before repo updates to record what was checked, what could conflict, and what action is recommended.
 
+## PFC-2026-07-15-012 — Shadow Pipeline v0.2 Result and v0.3 Targeted Trace
+
+Date: 2026-07-15
+Time: 00:58 PDT
+
+Target files:
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+Relevant history checked:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/SESSION_LOG.md`
+- `HeroForge_Shadow_Pipeline_Probe_v0.2.0.txt`
+- `HF_Shadow_Pipeline_Probe_v0.2.0_2026-07-15T07-40-40-928Z.json`
+- prior v0.1 sun-only, environmental-lighting, and full Booth-preset comparison results
+- current project rule requiring documentation before the next material probe/code stage
+
+Connected modules reviewed:
+- standalone Shadow Pipeline Probe v0.2.0 wrapper-selection logic
+- native sun, native shadow camera, native shadow matrix, and scene-graph dirty-state fields captured by the v0.2 report
+- Persistent Booth separation through current lighting/Booth documentation
+- `manifest.json` loading rules through `MASTER.md`; no manifest change required
+
+Conflict risks:
+- Documentation-only repository update.
+- No Witch Dock JavaScript files changed.
+- No standalone userscript probe source is committed by this documentation update.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or live runtime behavior changed.
+- The v0.2 `methodCallCount: 0` result must not be misreported as proof that no method-based refresh occurs; only inherited `toLocaleString` was actually wrapped.
+- The v0.2 run contained multiple watched UI interactions, so elapsed time between dirty and synchronized states is not treated as a clean automatic refresh delay.
+- The current evidence supports an external renderer/scene-graph/camera-matrix update path, but no exact method or call chain is yet confirmed.
+- v0.3.0 remains a standalone unvalidated test artifact until a live HeroForge report is reviewed.
+- Persistent Booth remains live/working and separate; no edit to `tools/Booth.js` is justified.
+- `Knight-Witch/HeroForge.Compatibility` remains out of scope.
+
+Recommended action:
+- Record v0.2 as a negative-result milestone that closes direct `sun.shadow` method tracing as the current target.
+- Preserve v0.2 unchanged.
+- Use v0.3 to wrap only specific live sun/camera/vector/matrix instances and targeted transform/matrix mutators.
+- Do not patch global prototypes or invoke guessed refresh methods.
+- Have native Sun controls already open before arming v0.3, then perform one sun adjustment only.
+
 ## PFC-2026-07-14-011 — Native Shadow Refresh Comparison Checkpoint
 
 Date: 2026-07-14


### PR DESCRIPTION
Documentation-only checkpoint for Shadow Pipeline Probe v0.2.0 and the next v0.3.0 trace target.

- Records that the v0.2 trace targeted the wrong object: native `sun.shadow` exposed only `clone`, `copy`, and `toJSON` beyond plain `Object` methods.
- Corrects the zero-call interpretation: v0.2 accidentally wrapped only inherited `toLocaleString`, so `methodCallCount: 0` does not prove the refresh path is method-free.
- Records matrix-dirty state on the native sun/lighting root before a later synchronized shadow-camera/matrix state.
- Preserves the limitation that the v0.2 run contained multiple watched interactions, so that interval is not treated as a clean refresh delay.
- Records the v0.3 plan to trace only specific live sun, camera, vector, and matrix instances without global prototype patching or guessed method invocation.

Documentation only. No Witch Dock JavaScript, standalone probe source, manifest, storage, UI, Persistent Booth, or runtime behavior changed.