### PR TITLE
Document archived HeroForge debug and slot references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Time: 00:58 PDT
 - Confirmed that native `sun.shadow` exposes no obvious callable refresh/update method in its observed prototype chain; beyond plain `Object` methods, the inventory found only `clone`, `copy`, and `toJSON`.
 - Corrected the v0.2 zero-call interpretation: the trace excluded `clone`, `copy`, and `toJSON`, accidentally wrapped inherited `toLocaleString`, and therefore recorded zero calls to an irrelevant method. This does not prove that the refresh path is method-free.
 - Recorded one v0.2 transition where the native sun and lighting root were matrix-dirty while the shadow camera/matrix were stale, followed by a later synchronized camera/matrix state with those dirty flags cleared.
-- Recorded the timing limitation that the v0.2 run contained multiple watched UI interactions, so the elapsed time between those states is not treated as a clean automatic refresh delay.
+- Recorded the timing limitation that the v0.2 run contained multiple watched UI interactions, so the elapsed time between those dirty and synchronized states is not treated as an isolated automatic refresh delay.
 - Narrowed the next target to specific live sun, sun-position, sun-target-position, shadow-camera, shadow-camera-position, and shadow-matrix instances rather than `sun.shadow` itself.
 - Recorded `HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` as a newly created local standalone test artifact that passed syntax and stub-initialization checks but has not yet been runtime-validated in HeroForge.
 
@@ -255,7 +255,7 @@ Time: 19:12 PDT
 
 - Corrected the earlier active claim that v0.3 had proven reliable visible independent custom DirectionalLight shadows. Later controlled v0.4-v0.5 runs did not reproduce that visual result; independent visible custom shadows remain unconfirmed and currently appear non-working.
 - Confirmed v0.4 found at least two `HF.summonCircle` materials using `additionalSunShadow: true` with `additionalSunShadowMap` textures distinct from the native `sun.shadow.map`.
-- Confirmed that copying probe state onto the native sun caused visible native shadows to disappear and restoring the original native sun state caused visible shadows to return.
+- Confirmed that copying probe state onto the native sun caused visible native sun shadows to disappear and restoring the original native sun state caused visible shadows to return.
 - Confirmed v0.5 retained the same native `sun.shadow.map` object and the same two `additionalSunShadowMap` texture objects across working baseline -> broken override -> restored state.
 - Confirmed the direct material owners of the observed `additionalSunShadowMap` textures at `HF.summonCircle.children[0/1].material.uniforms.additionalSunShadowMap.value`.
 - Recorded `HeroForge_Lighting_Injection_Probe_v0.6.0.txt` as the current active diagnostic probe for texture/source/image/backing-resource state, but explicitly not yet validated by a returned runtime report at this checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## DOCS-2026-07-22-013 — HeroForge Debug, Slot, Joint, and Lob Archive References
+
+Date: 2026-07-22
+Time: 20:20 PDT
+
+### Added
+
+- Added `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md` with the archived native HeroForge debug-loader model, debug-panel inventory, scene/texture/skeleton/JSON/animator references, known animator defects, wireframe gating limitation, and v0.2 compatibility defects.
+- Added `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md` with sourced/free slot schema notes, dataset statistics, joint ranges, duplicate/malformed source entries, cross-reference opportunities, and safe-use rules.
+- Added `HISTORY/REFERENCES/README.md` as the source manifest for exact filenames, SHA-256 hashes, provenance, parsed dataset counts, Lob archive inventory, and raw-reference storage rules.
+
+### Changed
+
+- Updated `HISTORY/README.md` to index the new topic files and source manifest and to define raw-reference storage rules.
+- Updated `HISTORY/Bullshit_Bible.md` with critical rules and high-risk summaries for archived debug internals and historical slot/joint/attachment data.
+- Updated `HISTORY/STANDALONE_REFERENCES.md` with archived Debug UI v0.1/v0.2 and the 2026-07-19 Lob public script archive, including status, source state, relevance, boundaries, and migration rules.
+- Updated `HISTORY/DECISIONS.md` with the decision to use distilled topic notes plus a source manifest for large unstable external archives unless repo-local raw copies become materially necessary.
+- Updated `HISTORY/SESSION_LOG.md` with the reference checkpoint, dataset findings, archive inventory, storage decision, and future-use scope.
+- Updated `PRE_FLIGHT_Check.md` with target files, history checked, connected modules reviewed, conflict risks, and recommended action.
+
+### Confirmed / Corrected Documentation
+
+- Confirmed the two supplied Debug UI v0.2 files are byte-identical and recorded their shared hash.
+- Confirmed the archived debug bundle identifies a November 6, 2024 HeroForge production build and should be treated as version-bound internal tooling.
+- Recorded that the archived animator stores complete character-state snapshots rather than conventional per-bone keyframes and relies on Photo Booth/token-renderer initialization.
+- Recorded that Debug UI v0.2 remains partially broken because removed webpack imports still have downstream references.
+- Confirmed `Sourced_Slots` contains 366 unique entries and `Free_Slots` contains 121 unique entries.
+- Confirmed every free-slot key is present in the sourced catalog and its preserved field values match the corresponding sourced entry.
+- Corrected the meaning of `Free_Slots`: it is a filtered historical subset, not proof that a slot is currently safe, available, unlocked, writable, or compatible.
+- Confirmed the numbered-joint snapshot contains 641 non-separator rows and 639 unique numeric IDs.
+- Recorded duplicate joint IDs `1204` and `1425` and three source entries lacking the normal `_bind_jnt` suffix.
+- Inventoried the Lob public archive's individual script filenames and internal metadata versions and recorded that filenames must not be used as the sole version source.
+- Preserved `Knight-Witch/HeroForge.Compatibility` as a separate project boundary and kept Persistent Booth separate and unchanged.
+
+### Source Evidence
+
+- `Enable Debug on HeroForge-0.1.txt`
+- `Enable Debug on HeroForge-0.2.txt`
+- `Enable Debug on HeroForge-0.2(1).txt`
+- `Sourced_Slots(1).txt`
+- `Free_Slots(1).txt`
+- `Numbered_Joint_IDs__21_.txt`
+- `hf-scripts-public-master.zip`
+- Exact hashes, archive source identifier, and parsed statistics are recorded in `HISTORY/REFERENCES/README.md`.
+
+### Touched Files
+
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+- `HISTORY/REFERENCES/README.md`
+- `HISTORY/README.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+### Rollback Notes
+
+- Documentation-only reference checkpoint.
+- No Witch Dock JavaScript files changed.
+- No standalone userscript/probe source was committed.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, Persistent Booth behavior, or live runtime behavior changed.
+- Rolling back would remove the durable source hashes, archive inventory, dataset caveats, and extracted debug/slot/joint reference findings but would not affect the installed userscript.
+
+### Test Notes
+
+- Parsed and compared the supplied JSON slot datasets.
+- Checked joint-list numeric ranges, duplicate IDs, and suffix anomalies.
+- Compared the two supplied v0.2 debug files byte-for-byte.
+- Inspected the Lob ZIP inventory and userscript metadata headers.
+- Documentation links and source-manifest references were cross-checked on the documentation branch.
+- No HeroForge runtime test was required because no executable code or live configuration changed.
+
 ## DOCS-2026-07-15-012 — Shadow Pipeline Probe v0.2 Negative Result and v0.3 Target
 
 Date: 2026-07-15
@@ -16,7 +92,7 @@ Time: 00:58 PDT
 - Confirmed that native `sun.shadow` exposes no obvious callable refresh/update method in its observed prototype chain; beyond plain `Object` methods, the inventory found only `clone`, `copy`, and `toJSON`.
 - Corrected the v0.2 zero-call interpretation: the trace excluded `clone`, `copy`, and `toJSON`, accidentally wrapped inherited `toLocaleString`, and therefore recorded zero calls to an irrelevant method. This does not prove that the refresh path is method-free.
 - Recorded one v0.2 transition where the native sun and lighting root were matrix-dirty while the shadow camera/matrix were stale, followed by a later synchronized camera/matrix state with those dirty flags cleared.
-- Recorded the timing limitation that the v0.2 run contained multiple watched UI interactions, so the elapsed time between those dirty and synchronized states is not treated as an isolated automatic refresh delay.
+- Recorded the timing limitation that the v0.2 run contained multiple watched UI interactions, so the elapsed time between those states is not treated as a clean automatic refresh delay.
 - Narrowed the next target to specific live sun, sun-position, sun-target-position, shadow-camera, shadow-camera-position, and shadow-matrix instances rather than `sun.shadow` itself.
 - Recorded `HeroForge_Shadow_Pipeline_Probe_v0.3.0.txt` as a newly created local standalone test artifact that passed syntax and stub-initialization checks but has not yet been runtime-validated in HeroForge.
 

--- a/HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md
+++ b/HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md
@@ -1,0 +1,183 @@
+# Debug UI and Internal Runtime References
+
+Historical notes extracted from the archived HeroForge `DebugLive` bundle and Lob's compatibility userscripts.
+
+## Status
+
+- Historical diagnostic reference only.
+- The archived bundle identifies itself as `Prod 11/6/24`, branch `release/hf_2024_11_06`, build `V30190`.
+- Do not load or integrate the complete debug userscript into Witch Dock.
+- Treat every API, webpack module ID, object path, permission gate, and UI component as version-bound until current runtime probing confirms it.
+
+## Source Snapshot
+
+Files supplied in the GPT project:
+
+- `Enable Debug on HeroForge-0.1.txt`
+- `Enable Debug on HeroForge-0.2.txt` / duplicate `Enable Debug on HeroForge-0.2(1).txt`
+
+Source hashes are recorded in `HISTORY/REFERENCES/README.md`.
+
+## Loader Behavior
+
+The userscript performs two separate operations:
+
+1. Waits for `CK`, then sets:
+   - `CK.User.permissions.test = true`
+   - `CK.Settings.debug = true`
+2. Replaces a requested gated `debuglive` script with an archived HeroForge webpack chunk loaded from a Blob URL.
+
+This is why the interface appears native: the script is primarily restoring HeroForge's own archived debug module rather than independently recreating the UI.
+
+Version `0.2` additionally blocks obsolete requests for:
+
+- `/static/herobundles/test.ckb`
+- `/static/textures/grid.jpg`
+
+It also changes an old release-data path from `CK.Options.decalsBySlot.releases` to `CK.Options.releases`.
+
+## Native Debug Sections
+
+The archived top-level interface exposes:
+
+- Releases
+- Smoke testing
+- Scene
+- Textures
+- Data
+- Parts
+- Mods
+- Poses
+- Display
+- Animator
+- CSV
+
+Most of this is internal production QA tooling, not finished user-facing functionality.
+
+## High-Value Technical References
+
+### Scene graph outliner
+
+The Scene panel:
+
+- recursively traverses `CK.scene`;
+- searches node names;
+- displays node name/type/UUID relationships;
+- attaches an `EX.Transformer` directly to a selected scene node;
+- disables orbit controls while the transformer is dragging;
+- requests render refreshes after interaction.
+
+Use this as a reference for tolerant scene discovery and native transform-gizmo behavior. Do not assume direct scene-node transforms persist into character JSON.
+
+### Texture and material-uniform inspector
+
+The Textures panel:
+
+- combines flattened character meshes with scene occlusion meshes;
+- inspects primary and bake-material uniforms;
+- identifies texture uniforms;
+- renders GPU textures into a temporary render target;
+- reads RGBA pixels back into canvases;
+- exposes full RGBA plus individual red, green, blue, and alpha channels.
+
+This is relevant to AAID, mask, baked-color, custom-texture, material-binding, and lighting/shadow investigation. The archived implementation changes renderer state and does not consistently restore every field, so it is a behavioral reference rather than safe copy-paste code.
+
+### Skeleton pose/modifier inspector
+
+The Poses panel enumerates:
+
+- `CK.activeDisplay.skeletons`
+- `CK.activeDisplay.partSkeletons`
+- `mainPoses`
+- `currentPoses`
+- active modifiers and modifier priorities
+
+It toggles modifiers through each skeleton's native `changePose()` path and requests animation refreshes. This is useful for discovering modifier names, skeleton ownership, priority behavior, and runtime pose composition.
+
+### Modifier-condition debugger
+
+The Mods panel reads `CK.activeModded._mods.debugModCache`, evaluated conditions, source files, slots, effects, and global/part modifier groups. It can disable groups through `CK.disableMods` and `CK.disableModsGlobal`.
+
+This is useful for diagnosing why parts or pose systems activate, but it should remain a private developer probe.
+
+### Live character JSON editor
+
+The Data panel reads `CK.data.getJson(true)` and applies edited JSON with `CK.change()`.
+
+This overlaps with ReCK and dedicated JSON tools. Its main value is confirmation that HeroForge had an internal native JSON editing surface.
+
+### Parts CSV exporter
+
+The CSV section exports part ID, name, slot, search terms, release date/name, and description. It is simple enough to reimplement independently when needed.
+
+## Animator Model
+
+The archived Animator is not a conventional skeletal keyframe editor.
+
+Observed model:
+
+- recording listens for `characterChanged`;
+- each frame is a complete HeroForge character-state snapshot;
+- selecting a frame applies it with `CK.character.change(frame, true, false)`;
+- rendering feeds the state sequence to internal Photo Booth/token-renderer infrastructure;
+- camera start/end state is interpolated during rendering.
+
+The feature is better described as a character-state sequence recorder/render pipeline than a bone timeline.
+
+### Known animator defects
+
+- Camera rotation is built from the return value of `array.push("XYZ")`; that returns a number, not the intended rotation array.
+- Render can dereference missing start/end camera objects.
+- Empty timelines are not safely rejected.
+- Deleting the final frame can apply `undefined`.
+- Render preparation mutates stored frame objects through shallow copies.
+- Event listeners, scene objects, renderer settings, camera overrides, and Photo Booth dependencies have incomplete cleanup paths.
+- The renderer assumes Photo Booth/token infrastructure is initialized; this is consistent with the observed crash unless Photo Booth is opened first.
+
+Any future animation work must reconstruct the architecture with explicit validation and cleanup rather than extracting this block wholesale.
+
+## Wireframe and Unlock Gating
+
+The Display panel's Wireframe control only toggles character setting `settings.wireframe` through `CK.tweak()`.
+
+The archived debug userscripts contain no `isUnlocked` implementation or check. Therefore:
+
+- the debug UI exposes the setting;
+- current rendering does not necessarily honor it;
+- the actual unlock/material/render gate exists elsewhere in HeroForge core or gated bundles.
+
+Do not treat the visible toggle as the wireframe implementation.
+
+## Version 0.2 Compatibility Defect
+
+Version `0.2` removed archived webpack imports corresponding to variables later referenced as `f` and `g`, but did not remove all downstream calls to `f.Z` and `g.Z`.
+
+Result:
+
+- the script may load farther than `0.1`;
+- affected smoke-test components can still throw runtime `ReferenceError`s;
+- `0.2` is an emergency compatibility patch, not a completed port.
+
+## Recommended Extraction Order
+
+If a current project needs these capabilities, extract one standalone probe at a time:
+
+1. Scene Graph Inspector
+2. Material/Texture Uniform Inspector
+3. Skeleton Pose/Modifier Inspector
+4. Character-State Recorder
+5. Animation Render Pipeline Probe
+6. Metadata CSV Export
+
+Each extracted probe must use current runtime discovery, preserve lifecycle cleanup, and remain separate from live Witch Dock tools until validated.
+
+## Related Files
+
+- `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- `HISTORY/BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/REFERENCES/README.md`

--- a/HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md
+++ b/HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md
@@ -1,0 +1,211 @@
+# Slots, Joints, and Attachment Maps
+
+Historical reference notes extracted from the supplied HeroForge slot and numbered-joint datasets.
+
+## Status
+
+- Historical data snapshots, not current authoritative HeroForge catalogs.
+- Useful for discovery, comparison, migration planning, slot expansion, attachment targeting, and bone-name lookup.
+- Every key must be confirmed against the current runtime before live code depends on it.
+- Do not generate unconditional slot mutations from these files.
+
+## Source Snapshot
+
+Files supplied in the GPT project:
+
+- `Sourced_Slots(1).txt`
+- `Free_Slots(1).txt`
+- `Numbered_Joint_IDs__21_.txt`
+
+Source hashes are recorded in `HISTORY/REFERENCES/README.md`.
+
+## Sourced Slots Dataset
+
+The sourced-slots snapshot contains:
+
+- 366 entries;
+- 366 unique slot keys;
+- no duplicate slot keys in the supplied JSON;
+- a source note pointing to `https://pastebin.com/wYGb6n83`.
+
+Every entry contains:
+
+- `disableFilters`
+- `monsterGroup`
+- `skel`
+- `source`
+
+Frequently used optional fields include:
+
+- `display_name`
+- `menu`
+- `scheme_group`
+- `clear_group`
+- `addonJointParent`
+- `subMenu`
+- `monsterRootJoint`
+- `target_slot`
+- `partnerSlots`
+- `renameJointsOnLoad`
+- `anim_priority`
+- `detach`
+- `detachSkinned`
+- `detachKit`
+- `noMods`
+- `monsterSize`
+- `allowMonsters`
+- `slotApplyForms`
+- `keepTransforms`
+- `linkedSlot`
+
+### What the fields imply
+
+- `source` identifies the art/source slot whose assets or behavior are reused.
+- `target_slot` identifies the destination/parent slot relationship used for placement or compatibility.
+- `skel` and `monsterGroup` constrain the skeleton/runtime family.
+- `addonJointParent` and `monsterRootJoint` provide explicit attachment anchors.
+- `partnerSlots` identifies paired slot behavior such as upper/lower teeth.
+- `clear_group` and `scheme_group` describe replacement/color-group interactions.
+- `detach`, `detachSkinned`, and `detachKit` indicate slot behavior that should not be treated as ordinary attached geometry.
+
+These are data-model clues, not a complete specification of HeroForge's slot loader.
+
+## Free Slots Dataset
+
+The free-slots snapshot contains:
+
+- 121 entries;
+- 121 unique slot keys;
+- no duplicate slot keys;
+- every free-slot key is also present in the sourced-slots snapshot.
+
+The free entries preserve only:
+
+- `skel`
+- `source`
+- optional `target_slot`
+- optional `detach`
+
+All preserved field values match the corresponding sourced-slot entries exactly.
+
+Interpretation:
+
+- `Free_Slots` is a filtered subset of the full sourced-slot catalog, not an independent schema.
+- The name `free` should not be treated as proof that a slot is safe, unoccupied, unlocked, writable, or currently accepted by HeroForge.
+- Before using a candidate, inspect current `CK.Options.slots`, active character data, `doesConfigFit`, source/target compatibility, skeleton ownership, and current UI/catalog visibility.
+
+## Useful Slot Families
+
+The supplied sourced catalog includes substantial groups for:
+
+- horns;
+- tails;
+- extra limbs;
+- wings;
+- teeth;
+- earrings and facial piercings;
+- fingers/rings;
+- eyes;
+- held and attached items;
+- human body/clothing variants;
+- creature/companion skeleton families.
+
+This makes the snapshot useful for future:
+
+- extra-slot experiments;
+- slot-source remapping;
+- decal or part slot swapping;
+- creature attachment support;
+- generalized attachment selectors;
+- compatibility checks between human, alternate body, and creature skeletons.
+
+## Numbered Joint Dataset
+
+The numbered-joint snapshot contains:
+
+- 641 non-separator joint lines;
+- 639 unique numeric IDs;
+- numeric ranges `0-427`, `1176-1204`, `1240-1260`, `1425/1427-1565`, `5000`, `5022`, `5033-5040`, and `5046-5056`;
+- large intentional or historical gaps between those ranges.
+
+The list covers:
+
+- core human bind joints;
+- body-shape and proportion joints;
+- fingers, hands, arms, legs, feet, and posture helpers;
+- item, side-item, base, tail, wing, horn, ear, tongue, and kitbash snap/attach joints;
+- digitigrade leg/toe chains;
+- clothing/skirt adjustment joints;
+- hair chain joints.
+
+### Confirmed data defects
+
+Two numeric IDs are duplicated:
+
+- `1204`
+  - `main_legR_02_height_bot_1204_bind_jnt`
+  - `main_legR_02_fat_bot_1204_bind_jnt`
+- `1425`
+  - `main_hornFrontL_offset_1425_bind_jnt`
+  - `main_hornFrontL_attach_1425_bind_jnt`
+
+Three entries omit the normal `_bind_jnt` suffix:
+
+- `main_fingerR_01_04_0193`
+- `main_armR_posture_0386`
+- `main_armL_posture_0387`
+
+Do not silently normalize these values. Preserve the source text and verify the actual runtime node names before using them.
+
+## Cross-Reference Opportunities
+
+The slot and joint datasets can be cross-referenced through fields such as:
+
+- `addonJointParent`
+- `monsterRootJoint`
+- `monsterRootJointL`
+- `source`
+- `target_slot`
+- `skel`
+- `monsterGroup`
+
+For human horn slots, the sourced data directly references numbered joints such as:
+
+- `main_hornBackR_attach_1444_bind_jnt`
+- `main_hornBackL_attach_1435_bind_jnt`
+
+This confirms that the two datasets can help build a searchable slot-to-anchor map. It does not prove every slot uses an explicitly listed numbered joint or that the current runtime preserves the same IDs.
+
+## Safe Use Rules
+
+Before implementing slot or attachment behavior:
+
+1. Read the current values from `CK.Options.slots` and the active character/runtime.
+2. Compare the current slot record against the historical sourced snapshot.
+3. Verify the target skeleton and monster group.
+4. Confirm source/target/partner relationships.
+5. Confirm the anchor joint exists in the current scene/skeleton.
+6. Preserve tolerant lookup paths and delayed runtime readiness.
+7. Treat missing JSON fields as normal because HeroForge lazily emits data.
+8. Avoid unconditional catalog mutation.
+9. Keep experimental slot injection separate from live Witch Dock modules until validated.
+
+## Likely Future Uses
+
+- Searchable developer reference for slot/source/target relationships.
+- Runtime probe that compares historical entries against current `CK.Options.slots`.
+- Attachment-point browser built on the scene outliner reference.
+- Safer extra-slot and `doesConfigFit` experiments.
+- Decal Slot Swapper compatibility research.
+- Body/kitbash bone selector improvements.
+- Creature and companion slot support.
+
+## Related Files
+
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
+- `HISTORY/BULLSHIT/DECAL_SLOT_SWAPPER.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/REFERENCES/README.md`

--- a/HISTORY/Bullshit_Bible.md
+++ b/HISTORY/Bullshit_Bible.md
@@ -19,6 +19,9 @@ Use this file for high-level rules and links. Put detailed notes in `HISTORY/BUL
 - Use documentation checkpoints after meaningful validated results. Do not create a commit for every trivial repeated observation, but do not begin the next material probe/code stage while current docs are knowingly stale.
 - When a finding is disproved or becomes outdated, correct or remove the old claim instead of appending a contradictory active claim elsewhere.
 - Label uncertain conclusions as observed, inferred, or unproven. Do not promote inference to confirmed behavior without evidence.
+- Treat archived HeroForge debug bundles, slot catalogs, and numbered-joint lists as historical discovery references, not current runtime contracts.
+- Do not load archived external userscripts through `manifest.json` or place them beside live `/tools/` or `/HeroForge_UI/` modules.
+- Preserve source filenames and hashes for large external archives even when only distilled findings are committed.
 
 ## High-Risk Current Topics
 
@@ -80,15 +83,51 @@ Current rules:
 - Keep physical DirectionalLight/SphereLight injection separate from future shader-based rim lighting.
 - Keep Advanced Lighting runtime logic separate from `tools/Booth.js` even if the eventual UI lives under the Booth tab.
 
+### Archived Debug UI / Internal Tools
+
+Detailed notes live in:
+- `BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `BULLSHIT/KITBASHING_AND_BONES.md`
+- `BULLSHIT/DECALS_AND_TEXTURES.md`
+- `BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `../REFERENCES/README.md`
+
+Current rules:
+- The archived `DebugLive` bundle is a version-bound HeroForge internal QA interface, not a stable public API.
+- Extract one focused standalone probe at a time; do not migrate the complete debug userscript into Witch Dock.
+- Scene outliner, texture-uniform inspection, skeleton modifiers, character-state recording, and CSV export are useful references, but each requires current runtime validation.
+- The archived animator records complete character-state snapshots; it is not a normal per-bone keyframe editor.
+- Opening Photo Booth before render avoids one observed crash because the archived animator depends on Photo Booth/token-renderer initialization.
+- The archived Wireframe control only toggles a character setting; it does not contain the current `isUnlocked` or render-path gate.
+- Debug userscript v0.2 remains partially broken and must not be treated as a stable compatibility release.
+
+### Slots, Joints, and Attachments
+
+Detailed notes live in:
+- `BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+- `BULLSHIT/KITBASHING_AND_BONES.md`
+- `BULLSHIT/DECAL_SLOT_SWAPPER.md`
+- `../REFERENCES/README.md`
+
+Current rules:
+- `Sourced_Slots`, `Free_Slots`, and `Numbered_Joint_IDs` are historical snapshots only.
+- `Free_Slots` is a filtered subset of the sourced catalog; the name does not prove current safety, availability, unlock state, or compatibility.
+- Verify candidate slots against current `CK.Options.slots`, current skeleton/monster-group ownership, source/target relationships, and `doesConfigFit` behavior.
+- Verify every joint name against the live scene/skeleton before using it.
+- Preserve source defects rather than silently normalizing them; the joint snapshot contains duplicate numeric IDs and entries without `_bind_jnt` suffixes.
+- Keep experimental slot/catalog mutation conditional and separate from live modules until validated.
+
 ### Standalone / External References
 
 Detailed notes live in:
 - `../STANDALONE_REFERENCES.md`
+- `../REFERENCES/README.md`
 
 Current rule:
 - Working external/probe scripts must be inventoried and compared before migration or replacement.
 - Deprecated pre-Witch Dock scripts should not be run beside Witch Dock unless explicitly revived for regression comparison.
 - HF Core Tweaks / Lob decal-slot behavior remains an external canonical reference for slot expansion behavior.
+- Large archived external sources may be represented by hashes, provenance, inventory, and distilled notes instead of being copied beside production code.
 
 ## Topic Files
 
@@ -99,6 +138,8 @@ Current rule:
 - `BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
 - `BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
 - `BULLSHIT/LIGHTING_SHADOW_REFRESH_DIAGNOSTICS.md`
+- `BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
 - `BULLSHIT/KITBASHING_AND_BONES.md`
 - `BULLSHIT/JSON_AND_LIBRARY.md`
 - `BULLSHIT/MANIFEST_AND_LOADING.md`
@@ -109,3 +150,4 @@ Current rule:
 - Document current bone detection timing/path behavior in deeper detail.
 - Recover and inventory remaining standalone migration candidates in `HISTORY/STANDALONE_REFERENCES.md`.
 - Keep Advanced Lighting / Extra Lights documentation synchronized with each material probe milestone and correction.
+- If raw debug/slot archive files are later committed, preserve their recorded hashes and keep them under `HISTORY/REFERENCES/` with non-installing filenames.

--- a/HISTORY/DECISIONS.md
+++ b/HISTORY/DECISIONS.md
@@ -4,6 +4,27 @@ Durable decisions that should guide future repo work.
 
 ## Active Decisions
 
+### 2026-07-22 — Large External HeroForge Archives Use Distilled Notes and a Source Manifest
+
+Decision:
+- Store extracted technical findings from large, unstable, or obsolete external HeroForge archives in focused `HISTORY/BULLSHIT/` topic files.
+- Record exact filenames, SHA-256 hashes, provenance, archive inventory, and dataset statistics in `HISTORY/REFERENCES/README.md`.
+- Do not copy old executable userscripts into live `/tools/`, `/HeroForge_UI/`, or `manifest.json` merely for preservation.
+- Keep raw source files in the GPT project/file archive unless a later investigation materially requires repo-local copies.
+- If raw copies are later committed, place them under `HISTORY/REFERENCES/`, use non-installing `.txt` filenames, and never register them as live modules.
+
+Reason:
+- The archived debug bundle and Lob script archive are valuable reverse-engineering references but contain stale APIs, partial compatibility patches, and executable code that should not sit beside production modules.
+- Distilled notes make high-value findings searchable without implying that historical object paths or slot catalogs are current HeroForge contracts.
+- Source hashes and inventory preserve provenance and make exact raw files recoverable or verifiable later.
+
+Applies to:
+- `HISTORY/REFERENCES/README.md`
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- future external HeroForge archives and recovered standalone references
+
 ### 2026-07-13 — Advanced Lighting Uses One Dedicated Sub-Project Spec and a Separate Future Booth-Tab Module
 
 Decision:
@@ -178,49 +199,3 @@ Applies to:
 - `HeroForge_UI/Expanded_UI_Scroll_Guards.js`
 - `HeroForge_UI/HF_UI_Scroll_Split_Safe.js`
 - `tools/Utilities.js`
-
-### 2026-07-09 — Photo Mode PNG Series Must Preserve HF Booth Render Path
-
-Decision:
-- Future PNG series capture work should prioritize HeroForge's own Photo Booth/capture/export path where possible.
-- Capture work must preserve booth effects, overlays, and backgrounds when those are the intended output.
-- Do not treat DOM/CSS resizing or raw canvas capture as automatically equivalent to HeroForge Photo Booth export.
-
-Reason:
-- Prior probing found the 1:1 booth frame can be baked into the WebGL scene.
-- The user specifically needs Photo Booth effects/overlays.
-- Browser/Tampermonkey capture can access final pixels, but not hidden HDR/16-bit buffers.
-
-Applies to:
-- Future Photo Mode / PNG Series capture tool
-- `tools/Booth.js`
-- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
-- `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
-
-### 2026-07-09 — Photo Mode PNG Capture Starts Conservative
-
-Decision:
-- First implementation target should be conservative: 1024x1024, around 72 PNG frames, ZIP output, metadata/failure records, explicit arming, and validated frame dimensions.
-- 2048, 4K, 16:9 cinematic output, overlay compositing, and companion app ideas are later-stage features unless they fall out safely from the first working path.
-
-Reason:
-- High-resolution PNG sequences can stress browser memory, ZIP generation, and download behavior.
-- The capture path is not solved yet, so reliability and correct Photo Booth output matter before max resolution or expanded feature surface.
-
-Applies to:
-- `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
-- Future Photo Mode / PNG Series capture tool
-- `MASTER.md` migration queue
-
-## Entry Template
-
-### YYYY-MM-DD — Decision Title
-
-Decision:
-- 
-
-Reason:
-- 
-
-Applies to:
-- 

--- a/HISTORY/DECISIONS.md
+++ b/HISTORY/DECISIONS.md
@@ -199,3 +199,49 @@ Applies to:
 - `HeroForge_UI/Expanded_UI_Scroll_Guards.js`
 - `HeroForge_UI/HF_UI_Scroll_Split_Safe.js`
 - `tools/Utilities.js`
+
+### 2026-07-09 — Photo Mode PNG Series Must Preserve HF Booth Render Path
+
+Decision:
+- Future PNG series capture work should prioritize HeroForge's own Photo Booth/capture/export path where possible.
+- Capture work must preserve booth effects, overlays, and backgrounds when those are the intended output.
+- Do not treat DOM/CSS resizing or raw canvas capture as automatically equivalent to HeroForge Photo Booth export.
+
+Reason:
+- Prior probing found the 1:1 booth frame can be baked into the WebGL scene.
+- The user specifically needs Photo Booth effects/overlays.
+- Browser/Tampermonkey capture can access final pixels, but not hidden HDR/16-bit buffers.
+
+Applies to:
+- Future Photo Mode / PNG Series capture tool
+- `tools/Booth.js`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
+
+### 2026-07-09 — Photo Mode PNG Capture Starts Conservative
+
+Decision:
+- First implementation target should be conservative: 1024x1024, around 72 PNG frames, ZIP output, metadata/failure records, explicit arming, and validated frame dimensions.
+- 2048, 4K, 16:9 cinematic output, overlay compositing, and companion app ideas are later-stage features unless they fall out safely from the first working path.
+
+Reason:
+- High-resolution PNG sequences can stress browser memory, ZIP generation, and download behavior.
+- The capture path is not solved yet, so reliability and correct Photo Booth output matter before max resolution or expanded feature surface.
+
+Applies to:
+- `HISTORY/BULLSHIT/PHOTO_MODE_PNG_CAPTURE.md`
+- Future Photo Mode / PNG Series capture tool
+- `MASTER.md` migration queue
+
+## Entry Template
+
+### YYYY-MM-DD — Decision Title
+
+Decision:
+- 
+
+Reason:
+- 
+
+Applies to:
+- 

--- a/HISTORY/README.md
+++ b/HISTORY/README.md
@@ -8,7 +8,18 @@ This folder stores durable project memory that should survive chat boundaries, c
 - `DECISIONS.md`: durable project decisions and why they were made.
 - `STANDALONE_REFERENCES.md`: inventory of standalone scripts, external references, probes, deprecated scripts, and migration status.
 - `Bullshit_Bible.md`: index of HeroForge engine weirdness and fragile rules.
-- `BULLSHIT/`: topic-specific notes for recurring HeroForge behavior problems, including `LIGHTING_AND_EXTRA_LIGHTS.md` for the Advanced Lighting / Extra Lights sub-project.
+- `BULLSHIT/`: topic-specific notes for recurring HeroForge behavior problems, including:
+  - `LIGHTING_AND_EXTRA_LIGHTS.md` for the Advanced Lighting / Extra Lights sub-project.
+  - `DEBUG_UI_AND_INTERNALS.md` for the archived native debug bundle and internal inspector references.
+  - `SLOTS_JOINTS_AND_ATTACHMENTS.md` for historical slot catalogs, joint IDs, attachment anchors, and dataset caveats.
+- `REFERENCES/README.md`: source manifest, hashes, provenance, and archive inventory for external historical reference files.
+
+## Reference Storage Rules
+
+- Keep obsolete or external executable userscripts out of `/tools/`, `/HeroForge_UI/`, and `manifest.json`.
+- Prefer distilled technical notes plus a source manifest for large unstable archives.
+- If raw copies are later committed, keep them under `HISTORY/REFERENCES/` with non-installing `.txt` filenames.
+- Historical datasets and archived internal bundles are discovery aids, not current HeroForge contracts.
 
 ## Documentation Checkpoints
 

--- a/HISTORY/REFERENCES/README.md
+++ b/HISTORY/REFERENCES/README.md
@@ -1,0 +1,121 @@
+# Historical Reference Source Manifest
+
+This directory indexes external HeroForge source snapshots used to build durable project notes.
+
+The raw files are intentionally not live-loaded, registered in `manifest.json`, or treated as current HeroForge contracts.
+
+## Storage Decision
+
+For this checkpoint, the repository stores:
+
+- extracted technical findings;
+- source filenames;
+- source hashes;
+- dataset statistics;
+- archive inventory and provenance.
+
+The large raw debug bundles and external script archive remain in the GPT project files rather than being copied into the live Witch Dock branch. This avoids placing obsolete executable userscripts beside production code while retaining enough provenance to identify or re-upload the exact source later.
+
+If raw copies are added in a future archival pass, they should remain under `HISTORY/REFERENCES/`, use non-installing `.txt` filenames, and never be referenced by `manifest.json`.
+
+## Debug Bundle Sources
+
+### Enable Debug on HeroForge v0.1
+
+- Project filename: `Enable Debug on HeroForge-0.1.txt`
+- SHA-256: `680e26830db47919f981772e9fc9b13d6cc4c3ef9ee24ae7da4b1b1e649be0c8`
+- Size: approximately 80 KiB
+- Status: archived original / unstable historical diagnostic reference
+- Notes: restores an archived HeroForge `DebugLive` webpack bundle and modifies debug/test permissions.
+
+### Enable Debug on HeroForge v0.2
+
+- Project filenames:
+  - `Enable Debug on HeroForge-0.2.txt`
+  - `Enable Debug on HeroForge-0.2(1).txt`
+- The two supplied copies are byte-identical.
+- SHA-256: `52c4a4795feca02ffdbc248eb4f90bd88f7bd83ad3003ed3a66d7a702ee77944`
+- Size: approximately 81 KiB
+- Status: partial compatibility patch / still unstable historical diagnostic reference
+- Notes: blocks obsolete `test.ckb` and `grid.jpg` requests and changes one release-data path, but retains unresolved module-reference defects.
+
+Distilled notes:
+
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+
+## Slot and Joint Sources
+
+### Numbered Joint IDs
+
+- Project filename: `Numbered_Joint_IDs__21_.txt`
+- SHA-256: `eb6423f62af8fa2ebee3667526be2539ba4a97c3bab7ea0be30bb703e94b4459`
+- Size: approximately 23 KiB
+- Parsed non-separator rows: `641`
+- Unique numeric IDs: `639`
+- Known duplicate numeric IDs: `1204`, `1425`
+- Entries without `_bind_jnt` suffix: `3`
+
+### Sourced Slots
+
+- Project filename: `Sourced_Slots(1).txt`
+- SHA-256: `f22023036a4d5eee587e24d50cb5ea0244c87f17ccc74152034beec9cfb107e4`
+- Size: approximately 139 KiB
+- Parsed entries: `366`
+- Unique slot keys: `366`
+- Source note in file: `https://pastebin.com/wYGb6n83`
+
+### Free Slots
+
+- Project filename: `Free_Slots(1).txt`
+- SHA-256: `655ac0d6bbfc5175c1bf503e8149fe7f3278c2513a1cae177ef4c1b0f51c2db2`
+- Size: approximately 18 KiB
+- Parsed entries: `121`
+- Unique slot keys: `121`
+- Relationship: exact-key subset of the sourced-slots snapshot; preserved field values match the corresponding sourced entries.
+
+Distilled notes:
+
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+
+## Lob Public Script Archive Snapshot
+
+- Project filename: `hf-scripts-public-master.zip`
+- SHA-256: `89653b766a4f293a1a99a9034aaabf7ca790627c2d77b1e779aa54ee4a10d04f`
+- Archive source snapshot date: `2026-07-19`
+- Archive commit identifier embedded in ZIP comment/path metadata: `76e7cdd94a42ac8e4173682837cc8befa59db460`
+- Status: external historical reference archive; not live Witch Dock code.
+
+Archive inventory:
+
+- `2000_kitbash_parts-0.4.user.js`
+  - metadata version `0.8.6`
+- `Advanced_Decal_Posing-0.2.user.js`
+  - metadata version `0.99.1 (Clover Fix)`
+- `Camera_Control_Modifier-2025-03-19.user.js`
+  - metadata version `2025-03-20`
+- `FullResDecals.user.js`
+  - metadata version `0.78`
+- `HF Core Tweaks.user.js`
+  - metadata version `0.3.4.1`
+- `I_love_extra_slots-0.2.user.js`
+  - metadata version `0.6`
+- `Persistent_Booth_Lighting-2025-03-20__1_.user.js`
+  - metadata version `2025-03-20`
+- `Shader_Fix_for_Photo_Booth-2025-03-20.user.js`
+  - metadata version `2025-06-18`
+- `Numbered_Joint_IDs__21_.txt`
+- `hf_bodyLower_loRez_humanToes_normalMap2.webp`
+- source `README.md`
+
+Important filename/version mismatch rule:
+
+- Do not infer script version from the archive filename alone.
+- Use the userscript metadata header as the source version, then verify behavior separately.
+
+## Usage Rules
+
+- Historical snapshots are not proof of current runtime behavior.
+- Do not run archived scripts alongside Witch Dock unless explicitly performing an isolated compatibility comparison.
+- Do not migrate code without first comparing current HeroForge objects, event timing, state lifecycle, and working behavior.
+- Preserve exact source hashes when replacing or re-uploading raw files.
+- Record any future raw-file addition in `PRE_FLIGHT_Check.md` and `CHANGELOG.md`.

--- a/HISTORY/SESSION_LOG.md
+++ b/HISTORY/SESSION_LOG.md
@@ -2,6 +2,18 @@
 
 Chronological development and testing notes. Use this for concise project-state updates that matter across chats.
 
+## 2026-07-22 — Debug, Slot, Joint, and Lob Archive Reference Checkpoint
+
+- Target: preserve useful reverse-engineering information from Lob's archived HeroForge debug userscripts, public script archive, sourced/free slot catalogs, and numbered-joint list without treating stale executable code or historical data as live HeroForge contracts.
+- Action: added focused notes for the archived native debug UI and for slot/joint/attachment maps; added a source manifest with exact filenames, SHA-256 hashes, dataset statistics, archive inventory, and provenance; indexed the new references in the History README and Bullshit Bible.
+- Debug result: the archived `DebugLive` bundle contains useful scene-graph, texture-uniform, skeleton-modifier, JSON, animation-state, and CSV references, but v0.2 remains partially broken and the complete userscript should not be integrated into Witch Dock.
+- Slot result: `Free_Slots` is a 121-entry subset of the 366-entry sourced catalog with matching preserved fields; the word `free` does not prove current availability, safety, or compatibility.
+- Joint result: the numbered-joint snapshot contains 641 rows and 639 unique numeric IDs, including duplicate IDs `1204` and `1425` plus three entries lacking `_bind_jnt` suffixes.
+- Archive result: inventoried the 2026-07-19 Lob public script ZIP and recorded its embedded source commit identifier, individual script filenames, and metadata versions.
+- Storage decision: keep raw large executable archives in the GPT project files for now; commit distilled findings and a source manifest. Any future raw copies belong under `HISTORY/REFERENCES/` as non-installing `.txt` files and must never be manifest-loaded.
+- Test notes: documentation and source-data analysis only; no Witch Dock JavaScript, standalone userscript source, `manifest.json`, storage keys, UI, Persistent Booth, or runtime behavior changed.
+- Follow-up: use the new topic files as pre-read material before scene-inspector, texture-inspector, animator, slot-injection, attachment, bone, or slot-swapping work.
+
 ## 2026-07-15 — Shadow Pipeline Probe v0.2 Result and v0.3 Trace Target
 
 - Target: identify the callable native `sun.shadow` method responsible for the legitimate shadow-camera/matrix refresh observed in the v0.1 sun-only comparison.

--- a/HISTORY/STANDALONE_REFERENCES.md
+++ b/HISTORY/STANDALONE_REFERENCES.md
@@ -27,6 +27,7 @@ Status:
 Current source state:
 - Not stored as a Witch Dock module.
 - Reference came from Lob/HF Core Tweaks-style Tampermonkey scripts provided outside the repo.
+- A 2026-07-19 snapshot of Lob's public archive is inventoried in `HISTORY/REFERENCES/README.md`.
 
 Known behavior / relevance:
 - The working reference exposed extra decal slots beyond HeroForge default behavior.
@@ -38,11 +39,83 @@ Rules:
 - Diagnose against the working reference before editing Witch Dock slot expansion.
 - Do not make Witch Dock slot expansion unconditional.
 - Do not change unrelated HF Core Tweaks behavior when experimenting with slot count expansion.
+- Do not infer a userscript's actual version from an archive filename; verify the metadata header.
 
 Related files:
 - `HeroForge_UI/HF_UI_Slot_Bridge.js`
 - `HeroForge_UI/Expanded_Decal_Slots.js`
 - `tools/Utilities.js`
+- `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+- `HISTORY/REFERENCES/README.md`
+
+### Archived HeroForge Debug UI v0.1 / v0.2
+
+Status:
+- Historical diagnostic reference / unstable archived internal tooling.
+
+Files:
+- Project source: `Enable Debug on HeroForge-0.1.txt`
+- Project source: `Enable Debug on HeroForge-0.2.txt`
+- Duplicate project copy: `Enable Debug on HeroForge-0.2(1).txt`
+- Exact hashes and provenance: `HISTORY/REFERENCES/README.md`
+
+Current source state:
+- Raw executable copies remain in the GPT project files and are not committed as live repository scripts.
+- Distilled findings are stored in `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`.
+- The embedded HeroForge bundle identifies itself as a November 6, 2024 production build.
+
+Known behavior / relevance:
+- Restores an archived native HeroForge `DebugLive` webpack bundle through the gated debug-loader path.
+- Exposes native internal panels for scene graph inspection, material/texture uniforms, skeleton pose modifiers, modifier conditions, character JSON, asset QA, animation-state recording/rendering, and CSV export.
+- Provides strong behavioral references for scene traversal, native transform gizmos, GPU texture readback, and skeleton modifier discovery.
+- The animator records complete character-state snapshots rather than per-bone timeline keyframes and depends on Photo Booth/token-renderer initialization.
+- The Wireframe toggle only changes character setting state; the actual unlock/render gate is not present in the supplied debug bundle.
+- v0.2 blocks two obsolete resource requests and changes one release path, but retains unresolved module-reference defects.
+
+Rules:
+- Do not load or integrate the complete debug userscript into Witch Dock.
+- Treat every webpack module ID, object path, API, and permission gate as version-bound until current runtime probing confirms it.
+- Extract one focused standalone probe at a time.
+- Preserve renderer state and lifecycle cleanup when reusing texture-readback or scene-transform concepts.
+- Do not treat v0.2 as a stable compatibility release.
+
+Related files:
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/REFERENCES/README.md`
+
+### Lob Public HeroForge Script Archive — 2026-07-19 Snapshot
+
+Status:
+- External historical reference archive.
+
+File:
+- Project source: `hf-scripts-public-master.zip`
+- Exact hash, embedded source commit identifier, and archive inventory: `HISTORY/REFERENCES/README.md`
+
+Current source state:
+- Raw ZIP remains in the GPT project files.
+- It is not copied into the live Witch Dock branch or loaded by `manifest.json`.
+- Contents include HF Core Tweaks, Advanced Decal Posing, FullResDecals, extra-slot, kitbash-part, camera, Persistent Booth lighting, and Photo Booth shader scripts plus supporting reference data.
+
+Known behavior / relevance:
+- Preserves exact third-party source snapshots for future parity checks, recovery, and segmentation into isolated Tampermonkey tests.
+- Contains scripts whose archive filenames do not match their internal userscript metadata versions.
+- Includes the numbered-joint snapshot also documented in the slot/joint topic file.
+
+Rules:
+- Review and isolate individual scripts before testing; do not load the archive as a combined production package.
+- Treat a proven working standalone behavior as canonical until a migrated Witch Dock version is tested and confirmed.
+- Keep the separate `Knight-Witch/HeroForge.Compatibility` stabilization/refactor project out of Witch Dock feature work unless the user explicitly crosses that boundary.
+- Do not infer current HeroForge compatibility from the archive date alone.
+
+Related files:
+- `HISTORY/REFERENCES/README.md`
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
 - `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
 
 ### HeroForge Lighting Probe v0.1.0
@@ -390,16 +463,18 @@ Related files:
 ### Bone / Kitbashing Standalone Probes
 
 Status:
-- Needs recovery.
+- Partially recovered / further source review still needed.
 
 Known behavior / relevance:
 - Current Witch Dock footer bone detection uses tolerant scene-graph probing, baseline snapshots, delayed diffing, pointer/click listeners, and startup retries.
-- Additional standalone probing history may exist and should be recovered before major bone/kitbashing changes.
+- The numbered-joint snapshot and Lob archive now provide additional source data, but other standalone probing history may still exist.
 
 Related files:
 - `Witch_Dock.user.js`
 - `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
 - `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/REFERENCES/README.md`
 
 ### Remaining Standalone Tampermonkey Scripts from User Uploads
 
@@ -408,7 +483,7 @@ Status:
 
 Known behavior / relevance:
 - User has provided external Tampermonkey script bundles during prior debugging.
-- Each standalone script should be inventoried by filename/source once recovered or re-uploaded.
+- The 2026-07-19 Lob public archive is now inventoried, but other uploads may remain outside the current source manifest.
 
 Rules:
 - Do not assume an uploaded standalone is obsolete until reviewed.
@@ -419,6 +494,8 @@ Rules:
 | Reference | Status | Likely Destination | Current Rule |
 |---|---|---|---|
 | HF Core Tweaks / Lob decal reference | External canonical reference | Maybe `HeroForge_UI/` or direct HF Core Tweaks edit, depending on final strategy | Compare before slot-expansion edits. |
+| Archived HeroForge Debug UI v0.1/v0.2 | Historical diagnostic reference | Focused standalone developer probes only | Do not integrate wholesale; validate each extracted API/path against current runtime. |
+| Lob public script archive 2026-07-19 | External historical reference archive | Separate script-by-script testing / `HeroForge.Compatibility` where applicable | Inventory and isolate before testing; do not load as a combined package. |
 | HeroForge Lighting Probe v0.1.0 | Read-only unresolved probe | Diagnostics only | Preserve read-only; use for runtime/bundle discovery. |
 | Lighting Injection Probe v0.1.0 | Historical diagnostic reference | None directly | Preserve proof of second DirectionalLight and non-working counted SphereLight. |
 | Lighting Injection Probe v0.2.0 | Historical diagnostic reference | None directly | Preserve transform controls and post-attach-shadow control result. |
@@ -434,4 +511,4 @@ Rules:
 | Sync Extra Arms | Deprecated | None | Do not use with Witch Dock. |
 | Body Editor / Body Editor BETA | Deprecated | Current `tools/Body_Editor.js` | Only compare if debugging regression. |
 | JSON Bulk Backup variants | Deprecated | Current `tools/JSON_Tool.js` | Only compare if debugging regression. |
-| Bone/kitbashing probes | Needs recovery | TBD | Recover before major bone/kitbashing changes. |
+| Bone/kitbashing probes | Partially recovered | TBD | Use new joint/slot references, but recover remaining probes before major changes. |

--- a/PRE_FLIGHT_Check.md
+++ b/PRE_FLIGHT_Check.md
@@ -2,6 +2,79 @@
 
 Use this file before repo updates to record what was checked, what could conflict, and what action is recommended.
 
+## PFC-2026-07-22-013 — Debug, Slot, Joint, and Lob Archive Reference Checkpoint
+
+Date: 2026-07-22
+Time: 20:20 PDT
+
+Target files:
+- `HISTORY/BULLSHIT/DEBUG_UI_AND_INTERNALS.md`
+- `HISTORY/BULLSHIT/SLOTS_JOINTS_AND_ATTACHMENTS.md`
+- `HISTORY/REFERENCES/README.md`
+- `HISTORY/README.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+
+Relevant history checked:
+- `MASTER.md`
+- `PRE_FLIGHT_Check.md`
+- `CHANGELOG.md`
+- `HISTORY/README.md`
+- `HISTORY/Bullshit_Bible.md`
+- `HISTORY/STANDALONE_REFERENCES.md`
+- `HISTORY/DECISIONS.md`
+- `HISTORY/SESSION_LOG.md`
+- `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- `HISTORY/BULLSHIT/DECALS_AND_TEXTURES.md`
+- `HISTORY/BULLSHIT/DECAL_SLOT_SWAPPER.md`
+- `HISTORY/BULLSHIT/TIMING_AND_STATE.md`
+- `HISTORY/BULLSHIT/BOOTH_RENDERS_EXPORTS.md`
+- `HISTORY/BULLSHIT/LIGHTING_AND_EXTRA_LIGHTS.md`
+- uploaded `coding_rules.txt`
+- `Enable Debug on HeroForge-0.1.txt`
+- `Enable Debug on HeroForge-0.2.txt`
+- duplicate `Enable Debug on HeroForge-0.2(1).txt`
+- `Sourced_Slots(1).txt`
+- `Free_Slots(1).txt`
+- `Numbered_Joint_IDs__21_.txt`
+- `hf-scripts-public-master.zip` and its internal file inventory/userscript metadata headers
+- prior analysis of the archived HeroForge debug UI, animator, scene outliner, material/texture inspector, skeleton modifiers, JSON editor, and CSV exporter
+
+Connected modules reviewed:
+- `manifest.json` loading rules and directory roles through `MASTER.md`; no manifest change required
+- current conditional slot-expansion architecture through `HeroForge_UI/HF_UI_Slot_Bridge.js`, `HeroForge_UI/Expanded_Decal_Slots.js`, and existing documentation
+- current Witch Dock footer bone-detection behavior and tolerant scene-graph rules through `HISTORY/BULLSHIT/KITBASHING_AND_BONES.md`
+- Decal Slot Swapper's unresolved slot-compatibility scope through its dedicated spec
+- Photo Booth/Persistent Booth separation through current Booth and lighting documentation
+- `Knight-Witch/HeroForge.Compatibility` project boundary; no files in that repository were touched
+
+Conflict risks:
+- Documentation-only repository update.
+- No Witch Dock JavaScript files changed.
+- No standalone userscript or probe source is committed by this update.
+- No `manifest.json` changes.
+- No storage keys, UI, styles, APIs, globals, or runtime behavior changed.
+- The archived debug bundle identifies a November 2024 HeroForge build; its webpack IDs, internal paths, APIs, permission gates, and UI behavior are historical until current runtime probing confirms them.
+- Debug userscript v0.2 is only a partial compatibility patch and retains unresolved module-reference defects.
+- The sourced/free slot catalogs and numbered-joint list are historical snapshots, not current authoritative HeroForge data.
+- `Free_Slots` is a filtered subset name, not proof that the slots are currently safe, available, writable, unlocked, or compatible.
+- The numbered-joint source contains duplicate numeric IDs and entries without normal `_bind_jnt` suffixes; source defects must not be silently normalized.
+- Large raw executable archives are intentionally not copied beside production code; exact hashes and provenance are recorded instead.
+- Persistent Booth remains live/working and separate; no edit to `tools/Booth.js` is justified.
+- `Knight-Witch/HeroForge.Compatibility` remains out of scope for this Witch Dock documentation checkpoint.
+
+Recommended action:
+- Add segmented debug-internals and slot/joint/attachment topic files rather than expanding the Bullshit Bible into a monolithic reference dump.
+- Add `HISTORY/REFERENCES/README.md` as the source manifest for hashes, provenance, dataset statistics, and archive inventory.
+- Inventory the archived debug userscripts and Lob public archive in `HISTORY/STANDALONE_REFERENCES.md`.
+- Keep the raw executable/source files in the GPT project archive for now.
+- If raw copies are later committed, store them only under `HISTORY/REFERENCES/` with non-installing `.txt` filenames and never register them in `manifest.json`.
+- Require current runtime verification before any future tool depends on a historical slot, joint, scene path, webpack module, or debug API.
+
 ## PFC-2026-07-15-012 — Shadow Pipeline v0.2 Result and v0.3 Targeted Trace
 
 Date: 2026-07-15


### PR DESCRIPTION
## Summary

Documentation-only checkpoint for newly supplied HeroForge reference material.

- adds focused notes for the archived native Debug UI and internal runtime tools
- adds slot, joint, and attachment-map notes with dataset caveats
- adds a source manifest with exact filenames, hashes, provenance, statistics, and Lob archive inventory
- inventories the archived debug scripts and Lob public archive in standalone references
- records the raw-reference storage decision, session checkpoint, pre-flight entry, and changelog entry

## Scope

- no Witch Dock JavaScript changes
- no standalone userscript/probe source committed
- no `manifest.json` changes
- no storage, UI, Persistent Booth, or runtime behavior changes

Raw executable archives remain in the GPT project files. Future raw copies, if materially needed, belong under `HISTORY/REFERENCES/` as non-installing `.txt` files and must never be manifest-loaded.